### PR TITLE
Feature/#56 뉴스본문 스크래핑기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.10'
 
-    // OpenAi
+    //OpenAi
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:1.0.0-M5'
 
     //Swagger
@@ -61,6 +61,8 @@ dependencies {
     //RSS
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'com.rometools:rome:1.18.0'
+    implementation 'org.jsoup:jsoup:1.20.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
@@ -38,7 +38,39 @@ public enum RssSource {
     KHAN_SOCIETY("경향신문", NewsCategory.SOCIETY, "https://www.khan.co.kr/rss/rssdata/society_news.xml", "kh", true),
     KHAN_INTERNATIONAL("경향신문", NewsCategory.INTERNATIONAL, "https://www.khan.co.kr/rss/rssdata/world_news.xml", "kh", true),
     KHAN_ENTERTAINMENT("경향신문", NewsCategory.ENTERTAINMENT, "https://www.khan.co.kr/rss/rssdata/art_news.xml", "kh", true),
-    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true);
+    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true),
+
+    // MBN RSS 피드
+    MBN_POLITICS("MBN", NewsCategory.POLITICS, "https://www.mbn.co.kr/rss/politics/", "mb", true),
+    MBN_ECONOMY("MBN", NewsCategory.ECONOMY, "https://www.mbn.co.kr/rss/economy/", "mb", true),
+    MBN_SOCIETY("MBN", NewsCategory.SOCIETY, "https://www.mbn.co.kr/rss/society/", "mb", true),
+    MBN_INTERNATIONAL("MBN", NewsCategory.INTERNATIONAL, "https://www.mbn.co.kr/rss/international/", "mb", true),
+    MBN_ENTERTAINMENT("MBN", NewsCategory.ENTERTAINMENT, "https://www.mbn.co.kr/rss/enter/", "mb", true),
+    MBN_SPORTS("MBN", NewsCategory.SPORTS, "https://www.mbn.co.kr/rss/sports/", "mb", true),
+
+    // 조선일보 RSS 피드
+    CHOSUN_POLITICS("조선일보", NewsCategory.POLITICS, "https://www.chosun.com/arc/outboundfeeds/rss/category/politics/?outputType=xml", "cs", true),
+    CHOSUN_ECONOMY("조선일보", NewsCategory.ECONOMY, "https://www.chosun.com/arc/outboundfeeds/rss/category/economy/?outputType=xml", "cs", true),
+    CHOSUN_SOCIETY("조선일보", NewsCategory.SOCIETY, "https://www.chosun.com/arc/outboundfeeds/rss/category/national/?outputType=xml", "cs", true),
+    CHOSUN_INTERNATIONAL("조선일보", NewsCategory.INTERNATIONAL, "https://www.chosun.com/arc/outboundfeeds/rss/category/international/?outputType=xml", "cs", true),
+    CHOSUN_ENTERTAINMENT("조선일보", NewsCategory.ENTERTAINMENT, "https://www.chosun.com/arc/outboundfeeds/rss/category/entertainments/?outputType=xml", "cs", true),
+    CHOSUN_SPORTS("조선일보", NewsCategory.SPORTS, "https://www.chosun.com/arc/outboundfeeds/rss/category/sports/?outputType=xml", "cs", true),
+
+    // 한겨레 RSS 피드
+    HANI_POLITICS("한겨레", NewsCategory.POLITICS, "https://www.hani.co.kr/rss/politics/", "hn", true),
+    HANI_ECONOMY("한겨레", NewsCategory.ECONOMY, "https://www.hani.co.kr/rss/economy/", "hn", true),
+    HANI_SOCIETY("한겨레", NewsCategory.SOCIETY, "https://www.hani.co.kr/rss/society/", "hn", true),
+    HANI_INTERNATIONAL("한겨레", NewsCategory.INTERNATIONAL, "https://www.hani.co.kr/rss/international/", "hn", true),
+    HANI_ENTERTAINMENT("한겨레", NewsCategory.ENTERTAINMENT, "https://www.hani.co.kr/rss/culture/", "hn", true),
+    HANI_SPORTS("한겨레", NewsCategory.SPORTS, "https://www.hani.co.kr/rss/sports/", "hn", true),
+
+    // 한국경제 RSS 피드
+    HANKYUNG_POLITICS("한국경제", NewsCategory.POLITICS, "https://www.hankyung.com/feed/politics", "hk", true),
+    HANKYUNG_ECONOMY("한국경제", NewsCategory.ECONOMY, "https://www.hankyung.com/feed/economy", "hk", true),
+    HANKYUNG_SOCIETY("한국경제", NewsCategory.SOCIETY, "https://www.hankyung.com/feed/society", "hk", true),
+    HANKYUNG_INTERNATIONAL("한국경제", NewsCategory.INTERNATIONAL, "https://www.hankyung.com/feed/international", "hk", true),
+    HANKYUNG_ENTERTAINMENT("한국경제", NewsCategory.ENTERTAINMENT, "https://www.hankyung.com/feed/entertainment", "hk", true),
+    HANKYUNG_SPORTS("한국경제", NewsCategory.SPORTS, "https://www.hankyung.com/feed/sports", "hk", true);
 
     private final String publisherName;
     private final NewsCategory category;

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
@@ -38,8 +38,9 @@ public enum RssSource {
     KHAN_SOCIETY("경향신문", NewsCategory.SOCIETY, "https://www.khan.co.kr/rss/rssdata/society_news.xml", "kh", true,false),
     KHAN_INTERNATIONAL("경향신문", NewsCategory.INTERNATIONAL, "https://www.khan.co.kr/rss/rssdata/world_news.xml", "kh", true,false),
     KHAN_ENTERTAINMENT("경향신문", NewsCategory.ENTERTAINMENT, "https://www.khan.co.kr/rss/rssdata/art_news.xml", "kh", true,false),
-    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true,false),
+    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true,false);
 
+    /*
     // MBN RSS 피드
     MBN_POLITICS("MBN", NewsCategory.POLITICS, "https://www.mbn.co.kr/rss/politics/", "mb", true,false),
     MBN_ECONOMY("MBN", NewsCategory.ECONOMY, "https://www.mbn.co.kr/rss/economy/", "mb", true,false),
@@ -71,6 +72,7 @@ public enum RssSource {
     HANKYUNG_INTERNATIONAL("한국경제", NewsCategory.INTERNATIONAL, "https://www.hankyung.com/feed/international", "hk", true,false),
     HANKYUNG_ENTERTAINMENT("한국경제", NewsCategory.ENTERTAINMENT, "https://www.hankyung.com/feed/entertainment", "hk", true,false),
     HANKYUNG_SPORTS("한국경제", NewsCategory.SPORTS, "https://www.hankyung.com/feed/sports", "hk", true,false);
+    */
 
     private final String publisherName;
     private final NewsCategory category;

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
@@ -2,8 +2,7 @@ package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.col
 
 import lombok.Getter;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -136,6 +135,22 @@ public enum RssSource {
      */
     public boolean hasFullContent() {
         return hasFullContent;
+    }
+
+    /**
+     * 활성화된 RSS 소스 목록에서 매퍼 타입(언론사)별로 하나만 선택하여 반환
+     *
+     * @return 중복 제거된 RSS 소스 목록(언론사당 하나)
+     */
+    public static List<RssSource> getUniqueMapperSources() {
+        Map<String, RssSource> uniqueSources = new HashMap<>();
+
+        for (RssSource source : getEnabledSources()) {
+            String mapperType = source.getMapperType();
+            uniqueSources.putIfAbsent(mapperType, source);
+        }
+
+        return new ArrayList<>(uniqueSources.values());
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
@@ -17,73 +17,75 @@ import java.util.stream.Collectors;
 @Getter
 public enum RssSource {
     // 국민일보 RSS 피드
-    KMIB_POLITICS("국민일보", NewsCategory.POLITICS, "https://www.kmib.co.kr/rss/data/kmibPolRss.xml", "km", true),
-    KMIB_ECONOMY("국민일보", NewsCategory.ECONOMY, "https://www.kmib.co.kr/rss/data/kmibEcoRss.xml", "km", true),
-    KMIB_SOCIETY("국민일보", NewsCategory.SOCIETY, "https://www.kmib.co.kr/rss/data/kmibSocRss.xml", "km", true),
-    KMIB_INTERNATIONAL("국민일보", NewsCategory.INTERNATIONAL, "https://www.kmib.co.kr/rss/data/kmibIntRss.xml", "km", true),
-    KMIB_ENTERTAINMENT("국민일보", NewsCategory.ENTERTAINMENT, "https://www.kmib.co.kr/rss/data/kmibEntRss.xml", "km", true),
-    KMIB_SPORTS("국민일보", NewsCategory.SPORTS, "https://www.kmib.co.kr/rss/data/kmibSpoRss.xml", "km", true),
+    KMIB_POLITICS("국민일보", NewsCategory.POLITICS, "https://www.kmib.co.kr/rss/data/kmibPolRss.xml", "km", true,false),
+    KMIB_ECONOMY("국민일보", NewsCategory.ECONOMY, "https://www.kmib.co.kr/rss/data/kmibEcoRss.xml", "km", true,false),
+    KMIB_SOCIETY("국민일보", NewsCategory.SOCIETY, "https://www.kmib.co.kr/rss/data/kmibSocRss.xml", "km", true,false),
+    KMIB_INTERNATIONAL("국민일보", NewsCategory.INTERNATIONAL, "https://www.kmib.co.kr/rss/data/kmibIntRss.xml", "km", true,false),
+    KMIB_ENTERTAINMENT("국민일보", NewsCategory.ENTERTAINMENT, "https://www.kmib.co.kr/rss/data/kmibEntRss.xml", "km", true,false),
+    KMIB_SPORTS("국민일보", NewsCategory.SPORTS, "https://www.kmib.co.kr/rss/data/kmibSpoRss.xml", "km", true,false),
 
     // 동아일보 RSS 피드
-    DONGA_POLITICS("동아일보", NewsCategory.POLITICS, "https://rss.donga.com/politics.xml", "da", true),
-    DONGA_ECONOMY("동아일보", NewsCategory.ECONOMY, "https://rss.donga.com/economy.xml", "da", true),
-    DONGA_SOCIETY("동아일보", NewsCategory.SOCIETY, "https://rss.donga.com/national.xml", "da", true),
-    DONGA_INTERNATIONAL("동아일보", NewsCategory.INTERNATIONAL, "https://rss.donga.com/international.xml", "da", true),
-    DONGA_ENTERTAINMENT("동아일보", NewsCategory.ENTERTAINMENT, "https://rss.donga.com/entertainment.xml", "da", true),
-    DONGA_SPORTS("동아일보", NewsCategory.SPORTS, "https://rss.donga.com/sports.xml", "da", true),
+    DONGA_POLITICS("동아일보", NewsCategory.POLITICS, "https://rss.donga.com/politics.xml", "da", true,false),
+    DONGA_ECONOMY("동아일보", NewsCategory.ECONOMY, "https://rss.donga.com/economy.xml", "da", true,false),
+    DONGA_SOCIETY("동아일보", NewsCategory.SOCIETY, "https://rss.donga.com/national.xml", "da", true,false),
+    DONGA_INTERNATIONAL("동아일보", NewsCategory.INTERNATIONAL, "https://rss.donga.com/international.xml", "da", true,false),
+    DONGA_ENTERTAINMENT("동아일보", NewsCategory.ENTERTAINMENT, "https://rss.donga.com/entertainment.xml", "da", true,false),
+    DONGA_SPORTS("동아일보", NewsCategory.SPORTS, "https://rss.donga.com/sports.xml", "da", true,false),
 
     // 경향신문 RSS 피드
-    KHAN_POLITICS("경향신문", NewsCategory.POLITICS, "https://www.khan.co.kr/rss/rssdata/politic_news.xml", "kh", true),
-    KHAN_ECONOMY("경향신문", NewsCategory.ECONOMY, "https://www.khan.co.kr/rss/rssdata/economy_news.xml", "kh", true),
-    KHAN_SOCIETY("경향신문", NewsCategory.SOCIETY, "https://www.khan.co.kr/rss/rssdata/society_news.xml", "kh", true),
-    KHAN_INTERNATIONAL("경향신문", NewsCategory.INTERNATIONAL, "https://www.khan.co.kr/rss/rssdata/world_news.xml", "kh", true),
-    KHAN_ENTERTAINMENT("경향신문", NewsCategory.ENTERTAINMENT, "https://www.khan.co.kr/rss/rssdata/art_news.xml", "kh", true),
-    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true),
+    KHAN_POLITICS("경향신문", NewsCategory.POLITICS, "https://www.khan.co.kr/rss/rssdata/politic_news.xml", "kh", true,false),
+    KHAN_ECONOMY("경향신문", NewsCategory.ECONOMY, "https://www.khan.co.kr/rss/rssdata/economy_news.xml", "kh", true,false),
+    KHAN_SOCIETY("경향신문", NewsCategory.SOCIETY, "https://www.khan.co.kr/rss/rssdata/society_news.xml", "kh", true,false),
+    KHAN_INTERNATIONAL("경향신문", NewsCategory.INTERNATIONAL, "https://www.khan.co.kr/rss/rssdata/world_news.xml", "kh", true,false),
+    KHAN_ENTERTAINMENT("경향신문", NewsCategory.ENTERTAINMENT, "https://www.khan.co.kr/rss/rssdata/art_news.xml", "kh", true,false),
+    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true,false),
 
     // MBN RSS 피드
-    MBN_POLITICS("MBN", NewsCategory.POLITICS, "https://www.mbn.co.kr/rss/politics/", "mb", true),
-    MBN_ECONOMY("MBN", NewsCategory.ECONOMY, "https://www.mbn.co.kr/rss/economy/", "mb", true),
-    MBN_SOCIETY("MBN", NewsCategory.SOCIETY, "https://www.mbn.co.kr/rss/society/", "mb", true),
-    MBN_INTERNATIONAL("MBN", NewsCategory.INTERNATIONAL, "https://www.mbn.co.kr/rss/international/", "mb", true),
-    MBN_ENTERTAINMENT("MBN", NewsCategory.ENTERTAINMENT, "https://www.mbn.co.kr/rss/enter/", "mb", true),
-    MBN_SPORTS("MBN", NewsCategory.SPORTS, "https://www.mbn.co.kr/rss/sports/", "mb", true),
+    MBN_POLITICS("MBN", NewsCategory.POLITICS, "https://www.mbn.co.kr/rss/politics/", "mb", true,false),
+    MBN_ECONOMY("MBN", NewsCategory.ECONOMY, "https://www.mbn.co.kr/rss/economy/", "mb", true,false),
+    MBN_SOCIETY("MBN", NewsCategory.SOCIETY, "https://www.mbn.co.kr/rss/society/", "mb", true,false),
+    MBN_INTERNATIONAL("MBN", NewsCategory.INTERNATIONAL, "https://www.mbn.co.kr/rss/international/", "mb", true,false),
+    MBN_ENTERTAINMENT("MBN", NewsCategory.ENTERTAINMENT, "https://www.mbn.co.kr/rss/enter/", "mb", true,false),
+    MBN_SPORTS("MBN", NewsCategory.SPORTS, "https://www.mbn.co.kr/rss/sports/", "mb", true,false),
 
     // 조선일보 RSS 피드
-    CHOSUN_POLITICS("조선일보", NewsCategory.POLITICS, "https://www.chosun.com/arc/outboundfeeds/rss/category/politics/?outputType=xml", "cs", true),
-    CHOSUN_ECONOMY("조선일보", NewsCategory.ECONOMY, "https://www.chosun.com/arc/outboundfeeds/rss/category/economy/?outputType=xml", "cs", true),
-    CHOSUN_SOCIETY("조선일보", NewsCategory.SOCIETY, "https://www.chosun.com/arc/outboundfeeds/rss/category/national/?outputType=xml", "cs", true),
-    CHOSUN_INTERNATIONAL("조선일보", NewsCategory.INTERNATIONAL, "https://www.chosun.com/arc/outboundfeeds/rss/category/international/?outputType=xml", "cs", true),
-    CHOSUN_ENTERTAINMENT("조선일보", NewsCategory.ENTERTAINMENT, "https://www.chosun.com/arc/outboundfeeds/rss/category/entertainments/?outputType=xml", "cs", true),
-    CHOSUN_SPORTS("조선일보", NewsCategory.SPORTS, "https://www.chosun.com/arc/outboundfeeds/rss/category/sports/?outputType=xml", "cs", true),
+    CHOSUN_POLITICS("조선일보", NewsCategory.POLITICS, "https://www.chosun.com/arc/outboundfeeds/rss/category/politics/?outputType=xml", "cs", true,false),
+    CHOSUN_ECONOMY("조선일보", NewsCategory.ECONOMY, "https://www.chosun.com/arc/outboundfeeds/rss/category/economy/?outputType=xml", "cs", true,false),
+    CHOSUN_SOCIETY("조선일보", NewsCategory.SOCIETY, "https://www.chosun.com/arc/outboundfeeds/rss/category/national/?outputType=xml", "cs", true,false),
+    CHOSUN_INTERNATIONAL("조선일보", NewsCategory.INTERNATIONAL, "https://www.chosun.com/arc/outboundfeeds/rss/category/international/?outputType=xml", "cs", true,false),
+    CHOSUN_ENTERTAINMENT("조선일보", NewsCategory.ENTERTAINMENT, "https://www.chosun.com/arc/outboundfeeds/rss/category/entertainments/?outputType=xml", "cs", true,false),
+    CHOSUN_SPORTS("조선일보", NewsCategory.SPORTS, "https://www.chosun.com/arc/outboundfeeds/rss/category/sports/?outputType=xml", "cs", true,false),
 
     // 한겨레 RSS 피드
-    HANI_POLITICS("한겨레", NewsCategory.POLITICS, "https://www.hani.co.kr/rss/politics/", "hn", true),
-    HANI_ECONOMY("한겨레", NewsCategory.ECONOMY, "https://www.hani.co.kr/rss/economy/", "hn", true),
-    HANI_SOCIETY("한겨레", NewsCategory.SOCIETY, "https://www.hani.co.kr/rss/society/", "hn", true),
-    HANI_INTERNATIONAL("한겨레", NewsCategory.INTERNATIONAL, "https://www.hani.co.kr/rss/international/", "hn", true),
-    HANI_ENTERTAINMENT("한겨레", NewsCategory.ENTERTAINMENT, "https://www.hani.co.kr/rss/culture/", "hn", true),
-    HANI_SPORTS("한겨레", NewsCategory.SPORTS, "https://www.hani.co.kr/rss/sports/", "hn", true),
+    HANI_POLITICS("한겨레", NewsCategory.POLITICS, "https://www.hani.co.kr/rss/politics/", "hn", true,false),
+    HANI_ECONOMY("한겨레", NewsCategory.ECONOMY, "https://www.hani.co.kr/rss/economy/", "hn", true,false),
+    HANI_SOCIETY("한겨레", NewsCategory.SOCIETY, "https://www.hani.co.kr/rss/society/", "hn", true,false),
+    HANI_INTERNATIONAL("한겨레", NewsCategory.INTERNATIONAL, "https://www.hani.co.kr/rss/international/", "hn", true,false),
+    HANI_ENTERTAINMENT("한겨레", NewsCategory.ENTERTAINMENT, "https://www.hani.co.kr/rss/culture/", "hn", true,false),
+    HANI_SPORTS("한겨레", NewsCategory.SPORTS, "https://www.hani.co.kr/rss/sports/", "hn", true,false),
 
     // 한국경제 RSS 피드
-    HANKYUNG_POLITICS("한국경제", NewsCategory.POLITICS, "https://www.hankyung.com/feed/politics", "hk", true),
-    HANKYUNG_ECONOMY("한국경제", NewsCategory.ECONOMY, "https://www.hankyung.com/feed/economy", "hk", true),
-    HANKYUNG_SOCIETY("한국경제", NewsCategory.SOCIETY, "https://www.hankyung.com/feed/society", "hk", true),
-    HANKYUNG_INTERNATIONAL("한국경제", NewsCategory.INTERNATIONAL, "https://www.hankyung.com/feed/international", "hk", true),
-    HANKYUNG_ENTERTAINMENT("한국경제", NewsCategory.ENTERTAINMENT, "https://www.hankyung.com/feed/entertainment", "hk", true),
-    HANKYUNG_SPORTS("한국경제", NewsCategory.SPORTS, "https://www.hankyung.com/feed/sports", "hk", true);
+    HANKYUNG_POLITICS("한국경제", NewsCategory.POLITICS, "https://www.hankyung.com/feed/politics", "hk", true,false),
+    HANKYUNG_ECONOMY("한국경제", NewsCategory.ECONOMY, "https://www.hankyung.com/feed/economy", "hk", true,false),
+    HANKYUNG_SOCIETY("한국경제", NewsCategory.SOCIETY, "https://www.hankyung.com/feed/society", "hk", true,false),
+    HANKYUNG_INTERNATIONAL("한국경제", NewsCategory.INTERNATIONAL, "https://www.hankyung.com/feed/international", "hk", true,false),
+    HANKYUNG_ENTERTAINMENT("한국경제", NewsCategory.ENTERTAINMENT, "https://www.hankyung.com/feed/entertainment", "hk", true,false),
+    HANKYUNG_SPORTS("한국경제", NewsCategory.SPORTS, "https://www.hankyung.com/feed/sports", "hk", true,false);
 
     private final String publisherName;
     private final NewsCategory category;
     private final String url;
     private final String mapperType;
     private final boolean enabled;
+    private final boolean hasFullContent;
 
-    RssSource(String publisherName, NewsCategory category, String url, String mapperType, boolean enabled) {
+    RssSource(String publisherName, NewsCategory category, String url, String mapperType, boolean enabled, boolean hasFullContent) {
         this.publisherName = publisherName;
         this.category = category;
         this.url = url;
         this.mapperType = mapperType;
         this.enabled = enabled;
+        this.hasFullContent = hasFullContent;
     }
 
     /**
@@ -123,6 +125,15 @@ public enum RssSource {
         return Arrays.stream(values())
                 .filter(RssSource::isEnabled)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * RSS에 전체 내용 포함 여부 반환
+     *
+     * @return 전체 내용 포함 여부
+     */
+    public boolean hasFullContent() {
+        return hasFullContent;
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
@@ -10,34 +10,34 @@ import java.util.stream.Collectors;
  * 각 항목은 언론사, 카테고리, URL 정보를 포함
  *
  * @author 양병학
- * @since 2025-05-10
  * @modified 2025-05-12 표준 카테고리(NewsCategory) 도입 및 동아일보, 경향신문 카테고리별 피드 추가
+ * @since 2025-05-10
  */
 @Getter
 public enum RssSource {
     // 국민일보 RSS 피드
-    KMIB_POLITICS("국민일보", NewsCategory.POLITICS, "https://www.kmib.co.kr/rss/data/kmibPolRss.xml", "km", true,true),
-    KMIB_ECONOMY("국민일보", NewsCategory.ECONOMY, "https://www.kmib.co.kr/rss/data/kmibEcoRss.xml", "km", true,true),
-    KMIB_SOCIETY("국민일보", NewsCategory.SOCIETY, "https://www.kmib.co.kr/rss/data/kmibSocRss.xml", "km", true,true),
-    KMIB_INTERNATIONAL("국민일보", NewsCategory.INTERNATIONAL, "https://www.kmib.co.kr/rss/data/kmibIntRss.xml", "km", true,true),
-    KMIB_ENTERTAINMENT("국민일보", NewsCategory.ENTERTAINMENT, "https://www.kmib.co.kr/rss/data/kmibEntRss.xml", "km", true,true),
-    KMIB_SPORTS("국민일보", NewsCategory.SPORTS, "https://www.kmib.co.kr/rss/data/kmibSpoRss.xml", "km", true,true),
+    KMIB_POLITICS("국민일보", NewsCategory.POLITICS, "https://www.kmib.co.kr/rss/data/kmibPolRss.xml", "km", true, true),
+    KMIB_ECONOMY("국민일보", NewsCategory.ECONOMY, "https://www.kmib.co.kr/rss/data/kmibEcoRss.xml", "km", true, true),
+    KMIB_SOCIETY("국민일보", NewsCategory.SOCIETY, "https://www.kmib.co.kr/rss/data/kmibSocRss.xml", "km", true, true),
+    KMIB_INTERNATIONAL("국민일보", NewsCategory.INTERNATIONAL, "https://www.kmib.co.kr/rss/data/kmibIntRss.xml", "km", true, true),
+    KMIB_ENTERTAINMENT("국민일보", NewsCategory.ENTERTAINMENT, "https://www.kmib.co.kr/rss/data/kmibEntRss.xml", "km", true, true),
+    KMIB_SPORTS("국민일보", NewsCategory.SPORTS, "https://www.kmib.co.kr/rss/data/kmibSpoRss.xml", "km", true, true),
 
     // 동아일보 RSS 피드
-    DONGA_POLITICS("동아일보", NewsCategory.POLITICS, "https://rss.donga.com/politics.xml", "da", true,false),
-    DONGA_ECONOMY("동아일보", NewsCategory.ECONOMY, "https://rss.donga.com/economy.xml", "da", true,false),
-    DONGA_SOCIETY("동아일보", NewsCategory.SOCIETY, "https://rss.donga.com/national.xml", "da", true,false),
-    DONGA_INTERNATIONAL("동아일보", NewsCategory.INTERNATIONAL, "https://rss.donga.com/international.xml", "da", true,false),
-    DONGA_ENTERTAINMENT("동아일보", NewsCategory.ENTERTAINMENT, "https://rss.donga.com/entertainment.xml", "da", true,false),
-    DONGA_SPORTS("동아일보", NewsCategory.SPORTS, "https://rss.donga.com/sports.xml", "da", true,false),
+    DONGA_POLITICS("동아일보", NewsCategory.POLITICS, "https://rss.donga.com/politics.xml", "da", true, false),
+    DONGA_ECONOMY("동아일보", NewsCategory.ECONOMY, "https://rss.donga.com/economy.xml", "da", true, false),
+    DONGA_SOCIETY("동아일보", NewsCategory.SOCIETY, "https://rss.donga.com/national.xml", "da", true, false),
+    DONGA_INTERNATIONAL("동아일보", NewsCategory.INTERNATIONAL, "https://rss.donga.com/international.xml", "da", true, false),
+    DONGA_ENTERTAINMENT("동아일보", NewsCategory.ENTERTAINMENT, "https://rss.donga.com/entertainment.xml", "da", true, false),
+    DONGA_SPORTS("동아일보", NewsCategory.SPORTS, "https://rss.donga.com/sports.xml", "da", true, false),
 
     // 경향신문 RSS 피드
-    KHAN_POLITICS("경향신문", NewsCategory.POLITICS, "https://www.khan.co.kr/rss/rssdata/politic_news.xml", "kh", true,false),
-    KHAN_ECONOMY("경향신문", NewsCategory.ECONOMY, "https://www.khan.co.kr/rss/rssdata/economy_news.xml", "kh", true,false),
-    KHAN_SOCIETY("경향신문", NewsCategory.SOCIETY, "https://www.khan.co.kr/rss/rssdata/society_news.xml", "kh", true,false),
-    KHAN_INTERNATIONAL("경향신문", NewsCategory.INTERNATIONAL, "https://www.khan.co.kr/rss/rssdata/world_news.xml", "kh", true,false),
-    KHAN_ENTERTAINMENT("경향신문", NewsCategory.ENTERTAINMENT, "https://www.khan.co.kr/rss/rssdata/art_news.xml", "kh", true,false),
-    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true,false);
+    KHAN_POLITICS("경향신문", NewsCategory.POLITICS, "https://www.khan.co.kr/rss/rssdata/politic_news.xml", "kh", true, false),
+    KHAN_ECONOMY("경향신문", NewsCategory.ECONOMY, "https://www.khan.co.kr/rss/rssdata/economy_news.xml", "kh", true, false),
+    KHAN_SOCIETY("경향신문", NewsCategory.SOCIETY, "https://www.khan.co.kr/rss/rssdata/society_news.xml", "kh", true, false),
+    KHAN_INTERNATIONAL("경향신문", NewsCategory.INTERNATIONAL, "https://www.khan.co.kr/rss/rssdata/world_news.xml", "kh", true, false),
+    KHAN_ENTERTAINMENT("경향신문", NewsCategory.ENTERTAINMENT, "https://www.khan.co.kr/rss/rssdata/art_news.xml", "kh", true, false),
+    KHAN_SPORTS("경향신문", NewsCategory.SPORTS, "https://www.khan.co.kr/rss/rssdata/sports_news.xml", "kh", true, false);
 
     /*
     // MBN RSS 피드

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/batch/RssSource.java
@@ -17,12 +17,12 @@ import java.util.stream.Collectors;
 @Getter
 public enum RssSource {
     // 국민일보 RSS 피드
-    KMIB_POLITICS("국민일보", NewsCategory.POLITICS, "https://www.kmib.co.kr/rss/data/kmibPolRss.xml", "km", true,false),
-    KMIB_ECONOMY("국민일보", NewsCategory.ECONOMY, "https://www.kmib.co.kr/rss/data/kmibEcoRss.xml", "km", true,false),
-    KMIB_SOCIETY("국민일보", NewsCategory.SOCIETY, "https://www.kmib.co.kr/rss/data/kmibSocRss.xml", "km", true,false),
-    KMIB_INTERNATIONAL("국민일보", NewsCategory.INTERNATIONAL, "https://www.kmib.co.kr/rss/data/kmibIntRss.xml", "km", true,false),
-    KMIB_ENTERTAINMENT("국민일보", NewsCategory.ENTERTAINMENT, "https://www.kmib.co.kr/rss/data/kmibEntRss.xml", "km", true,false),
-    KMIB_SPORTS("국민일보", NewsCategory.SPORTS, "https://www.kmib.co.kr/rss/data/kmibSpoRss.xml", "km", true,false),
+    KMIB_POLITICS("국민일보", NewsCategory.POLITICS, "https://www.kmib.co.kr/rss/data/kmibPolRss.xml", "km", true,true),
+    KMIB_ECONOMY("국민일보", NewsCategory.ECONOMY, "https://www.kmib.co.kr/rss/data/kmibEcoRss.xml", "km", true,true),
+    KMIB_SOCIETY("국민일보", NewsCategory.SOCIETY, "https://www.kmib.co.kr/rss/data/kmibSocRss.xml", "km", true,true),
+    KMIB_INTERNATIONAL("국민일보", NewsCategory.INTERNATIONAL, "https://www.kmib.co.kr/rss/data/kmibIntRss.xml", "km", true,true),
+    KMIB_ENTERTAINMENT("국민일보", NewsCategory.ENTERTAINMENT, "https://www.kmib.co.kr/rss/data/kmibEntRss.xml", "km", true,true),
+    KMIB_SPORTS("국민일보", NewsCategory.SPORTS, "https://www.kmib.co.kr/rss/data/kmibSpoRss.xml", "km", true,true),
 
     // 동아일보 RSS 피드
     DONGA_POLITICS("동아일보", NewsCategory.POLITICS, "https://rss.donga.com/politics.xml", "da", true,false),

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/quartz/QuartzTriggerConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/config/quartz/QuartzTriggerConfig.java
@@ -10,40 +10,40 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QuartzTriggerConfig {
-	private final String cronExpression;
-	private final JobDetail articleCollectorJobDetail;
-	private final String articleCollectorJobDetailName = "articleCollectorJobDetail";
+    private final String cronExpression;
+    private final JobDetail articleCollectorJobDetail;
+    private final String articleCollectorJobDetailName = "articleCollectorJobDetail";
 
-	/**
-	 * 생성자 주입을 통해 Cron 표현식을 설정한다.
-	 *
-	 * @param cronExpression RSS 배치 실행 주기를 정의하는 Cron 표현식
-	 *                       application.yml에서 article-collector.quartz.cron 값을 로드 합니다.
-	 * @author 함예정
-	 * @since 2025-05-10
-	 */
-	public QuartzTriggerConfig(@Value("${article-collector.quartz.cron}") String cronExpression,
-								JobDetail articleCollectorJobDetail) {
-		this.cronExpression = cronExpression;
-		this.articleCollectorJobDetail = articleCollectorJobDetail;
-	}
+    /**
+     * 생성자 주입을 통해 Cron 표현식을 설정한다.
+     *
+     * @param cronExpression RSS 배치 실행 주기를 정의하는 Cron 표현식
+     *                       application.yml에서 article-collector.quartz.cron 값을 로드 합니다.
+     * @author 함예정
+     * @since 2025-05-10
+     */
+    public QuartzTriggerConfig(@Value("${article-collector.quartz.cron}") String cronExpression,
+                               JobDetail articleCollectorJobDetail) {
+        this.cronExpression = cronExpression;
+        this.articleCollectorJobDetail = articleCollectorJobDetail;
+    }
 
-	/**
-	 * RSS 수집 Quartz Trigger 빈 등록.
-	 *  - forJob: 이 Trigger 가 어떤 Quartz Job 과 연관되어 실행될지를 지정
-	 * - withIdentity: Scheduler 내에서 이 Trigger 를 고유하게 식별하기 위한 이름 지정
-	 * - withSchedule: Cron 표현식을 사용하여 실행 주기 설정
-	 *
-	 * @return RSS 배치 작업용 Trigger 객체
-	 * @author 함예정
-	 * @since 2025-05-10
-	 */
-	@Bean
-	public Trigger rssBatchTrigger() {
-		return TriggerBuilder.newTrigger()
-			.forJob(articleCollectorJobDetail)
-			.withIdentity(articleCollectorJobDetailName)
-			.withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
-			.build();
-	}
+    /**
+     * RSS 수집 Quartz Trigger 빈 등록.
+     * - forJob: 이 Trigger 가 어떤 Quartz Job 과 연관되어 실행될지를 지정
+     * - withIdentity: Scheduler 내에서 이 Trigger 를 고유하게 식별하기 위한 이름 지정
+     * - withSchedule: Cron 표현식을 사용하여 실행 주기 설정
+     *
+     * @return RSS 배치 작업용 Trigger 객체
+     * @author 함예정
+     * @since 2025-05-10
+     */
+    @Bean
+    public Trigger rssBatchTrigger() {
+        return TriggerBuilder.newTrigger()
+                .forJob(articleCollectorJobDetail)
+                .withIdentity(articleCollectorJobDetailName)
+                .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
+                .build();
+    }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssEntryProcessor.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssEntryProcessor.java
@@ -54,10 +54,6 @@ public class RssEntryProcessor implements ItemProcessor<RssSource, List<ArticleE
 		List<SyndEntry> rssParseResult = parseRss(source);
 		AbstractRssMapper mapper = getMapper(source);
 
-		if (rssParseResult.isEmpty()) {
-			return new ArrayList<>();
-		}
-
 		return buildArticleEntityList(source, rssParseResult, mapper);
 	}
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssEntryProcessor.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssEntryProcessor.java
@@ -53,6 +53,11 @@ public class RssEntryProcessor implements ItemProcessor<RssSource, List<ArticleE
 	public List<ArticleEntity> process(RssSource source) {
 		List<SyndEntry> rssParseResult = parseRss(source);
 		AbstractRssMapper mapper = getMapper(source);
+
+		if (rssParseResult.isEmpty()) {
+			return new ArrayList<>();
+		}
+
 		return buildArticleEntityList(source, rssParseResult, mapper);
 	}
 
@@ -63,9 +68,10 @@ public class RssEntryProcessor implements ItemProcessor<RssSource, List<ArticleE
 	 * @return 파싱된 RSS 엔트리 리스트
 	 * @since 2025-05-10
 	 * @author 함예정
+	 * @modified 2025-05-18 매퍼 타입 전달하도록 수정
 	 */
 	private List<SyndEntry> parseRss(RssSource source) {
-		return rssFeedReader.getFeed(source.getUrl());
+		return rssFeedReader.getFeed(source.getUrl(), source.getMapperType());
 	}
 
 	/**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssFeedReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssFeedReader.java
@@ -29,146 +29,151 @@ import lombok.extern.slf4j.Slf4j;
  * RSS 피드 URL을 통해 XML 피드를 읽고 파싱하여 {@link SyndEntry} 목록으로 반환하는 Reader 클래스.
  * Rome 라이브러리를 이용하여 RSS를 파싱하며, 유효하지 않은 URL 또는 파싱 오류에 대해 예외를 처리한다.
  *
- * @since 2025-05-10
  * @modified 2025-05-18 최신 발행일 이후 데이터만 필터링하는 기능 추가
+ * @since 2025-05-10
  */
 @Slf4j
 @Component
 public class RssFeedReader {
-	private final RssNewsRepository rssNewsRepository;
-	private static final Map<String, LocalDateTime> lastProcessedDateMap = new ConcurrentHashMap<>();
+    private final RssNewsRepository rssNewsRepository;
+    private static final Map<String, LocalDateTime> lastProcessedDateMap = new ConcurrentHashMap<>();
 
-	@Autowired
-	public RssFeedReader(RssNewsRepository rssNewsRepository) {
-		this.rssNewsRepository = rssNewsRepository;
-	}
+    @Autowired
+    public RssFeedReader(RssNewsRepository rssNewsRepository) {
+        this.rssNewsRepository = rssNewsRepository;
+    }
 
-	/**
-	 * 주어진 피드 URL로부터 RSS 피드를 파싱하고, 최신 발행일 이후의 {@link SyndEntry} 리스트를 반환한다.
-	 *
-	 * @param feedUrl RSS 피드의 URL 문자열
-	 * @param mapperType 매퍼 타입 (언론사 코드)
-	 * @return 파싱 및 필터링된 SyndEntry 목록
-	 * @since 2025-05-10
-	 * @modified 2025-05-18 최신 발행일 이후 데이터만 필터링하는 기능 추가
-	 * @author 함예정
-	 */
-	public List<SyndEntry> getFeed(String feedUrl, String mapperType) {
-		URL url = getURL(feedUrl);
-		URLConnection connection = openConnectionWithTimeout(url);
-		List<SyndEntry> entries = parseRssEntries(connection);
+    /**
+     * 주어진 피드 URL로부터 RSS 피드를 파싱하고, 최신 발행일 이후의 {@link SyndEntry} 리스트를 반환한다.
+     *
+     * @param feedUrl    RSS 피드의 URL 문자열
+     * @param mapperType 매퍼 타입 (언론사 코드)
+     * @return 파싱 및 필터링된 SyndEntry 목록
+     * @modified 2025-05-18 최신 발행일 이후 데이터만 필터링하는 기능 추가
+     * @author 함예정
+     * @since 2025-05-10
+     */
+    public List<SyndEntry> getFeed(String feedUrl, String mapperType) {
+        URL url = getURL(feedUrl);
+        URLConnection connection = openConnectionWithTimeout(url);
+        List<SyndEntry> entries = parseRssEntries(connection);
 
-		LocalDateTime latestPubDate = getLatestPubDate(mapperType);
+        LocalDateTime latestPubDate = getLatestPubDate(mapperType);
 
-		List<SyndEntry> filteredEntries = entries.stream()
-				.filter(entry -> isAfterLatestPubDate(entry, latestPubDate))
-				.collect(Collectors.toList());
+        List<SyndEntry> filteredEntries = entries.stream()
+                .filter(entry -> isAfterLatestPubDate(entry, latestPubDate))
+                .collect(Collectors.toList());
 
-		return filteredEntries;
-	}
+        return filteredEntries;
+    }
 
-	/**
-	 * 언론사별 최신 발행일 조회 (캐싱 추가)
-	 *
-	 * @param mapperType 매퍼 타입 (언론사 코드)
-	 * @return 최신 발행일 또는 기본값
-	 */
-	private LocalDateTime getLatestPubDate(String mapperType) {
-		String guidPrefix = mapperType.toUpperCase();
+    /**
+     * 언론사별 최신 발행일 조회 (캐싱 추가)
+     *
+     * @param mapperType 매퍼 타입 (언론사 코드)
+     * @return 최신 발행일 또는 기본값
+     */
+    private LocalDateTime getLatestPubDate(String mapperType) {
+        String guidPrefix = mapperType.toUpperCase();
 
-		LocalDateTime latestPubDate = rssNewsRepository.findLatestPubDateByGuidPrefix(guidPrefix);
+        LocalDateTime latestPubDate = rssNewsRepository.findLatestPubDateByGuidPrefix(guidPrefix);
 
-		if (latestPubDate == null) {
-			latestPubDate = LocalDateTime.now().minusDays(1);
-		}
+        if (latestPubDate == null) {
+            latestPubDate = getDefaultPubDate();
+        }
 
-		lastProcessedDateMap.put(mapperType, latestPubDate);
-		return latestPubDate;
-	}
+        lastProcessedDateMap.put(mapperType, latestPubDate);
+        return latestPubDate;
+    }
 
-	/**
-	 * 항목의 발행일이 최신 발행일보다 이후인지 확인
-	 *
-	 * @param entry RSS 항목
-	 * @param latestPubDate 최신 발행일
-	 * @return 최신 발행일 이후면 true
-	 */
-	private boolean isAfterLatestPubDate(SyndEntry entry, LocalDateTime latestPubDate) {
-		if (entry.getPublishedDate() == null) {
-			log.debug("발행일 없음 - 항목 제외: {}", entry.getTitle());
-			return false;
-		}
+    private LocalDateTime getDefaultPubDate() {
+        LocalDateTime latestPubDate = LocalDateTime.now().minusDays(1);
+        return latestPubDate;
+    }
 
-		LocalDateTime pubDate = convertToLocalDateTime(entry.getPublishedDate());
+    /**
+     * 항목의 발행일이 최신 발행일보다 이후인지 확인
+     *
+     * @param entry         RSS 항목
+     * @param latestPubDate 최신 발행일
+     * @return 최신 발행일 이후면 true
+     */
+    private boolean isAfterLatestPubDate(SyndEntry entry, LocalDateTime latestPubDate) {
+        if (entry.getPublishedDate() == null) {
+            log.debug("발행일 없음 - 항목 제외: {}", entry.getTitle());
+            return false;
+        }
 
-		boolean isAfter = pubDate.isAfter(latestPubDate);
+        LocalDateTime pubDate = convertToLocalDateTime(entry.getPublishedDate());
 
-		return isAfter;
-	}
+        boolean isAfter = pubDate.isAfter(latestPubDate);
 
-	/**
-	 * Date 객체를 LocalDateTime으로 변환
-	 *
-	 * @param date 변환할 Date 객체
-	 * @return 변환된 LocalDateTime
-	 */
-	private LocalDateTime convertToLocalDateTime(Date date) {
-		return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-	}
+        return isAfter;
+    }
 
-	/**
-	 * 문자열 형태의 URL을 {@link URL} 객체로 변환한다.
-	 *
-	 * @param feedUrl 문자열 형태의 URL
-	 * @return URL 객체
-	 * @throws RuntimeException 유효하지 않은 URL 형식일 경우
-	 * @since 2025-05-10
-	 * @author 함예정
-	 */
-	private URL getURL(String feedUrl) {
-		try {
-			return new URL(feedUrl);
-		} catch (MalformedURLException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    /**
+     * Date 객체를 LocalDateTime으로 변환
+     *
+     * @param date 변환할 Date 객체
+     * @return 변환된 LocalDateTime
+     */
+    private LocalDateTime convertToLocalDateTime(Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
 
-	/**
-	 * 지정된 URL에 대해 연결 타임아웃과 읽기 타임아웃을 설정한 후 URLConnection을 반환합니다.
-	 *
-	 * @param url 연결할 URL 객체
-	 * @return 설정된 타임아웃을 가진 URLConnection 객체
-	 * @throws RuntimeException 연결 중 IOException이 발생할 경우 런타임 예외로 래핑하여 던짐
-	 * @author 함예정
-	 * @since 2025-05-12
-	 */
-	private URLConnection openConnectionWithTimeout(URL url) {
-		try {
-			URLConnection connection = url.openConnection();
-			connection.setConnectTimeout(3000);
-			connection.setReadTimeout(5000);
-			return connection;
-		} catch (IOException e) {
-			throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_CONNECTION_ERROR, e);
-		}
-	}
+    /**
+     * 문자열 형태의 URL을 {@link URL} 객체로 변환한다.
+     *
+     * @param feedUrl 문자열 형태의 URL
+     * @return URL 객체
+     * @throws RuntimeException 유효하지 않은 URL 형식일 경우
+     * @author 함예정
+     * @since 2025-05-10
+     */
+    private URL getURL(String feedUrl) {
+        try {
+            return new URL(feedUrl);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	/**
-	 * 주어진 URLConnection으로부터 RSS 피드를 읽어 SyndEntry 목록으로 파싱합니다.
-	 *
-	 * @param connection RSS 피드를 제공하는 URLConnection 객체
-	 * @return 파싱된 SyndEntry 객체 리스트
-	 * @throws ArticleCollectorException RSS 피드 파싱 중 오류가 발생한 경우 사용자 정의 예외로 래핑하여 던짐
-	 * @author 함예정
-	 * @since 2025-05-12
-	 */
-	private List<SyndEntry> parseRssEntries(URLConnection connection) {
-		try (XmlReader reader = new XmlReader(connection)) {
-			SyndFeedInput input = new SyndFeedInput();
-			SyndFeed syndFeed = input.build(reader);
-			return syndFeed.getEntries();
-		} catch (Exception e) {
-			throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_PARSING_ERROR, e);
-		}
-	}
+    /**
+     * 지정된 URL에 대해 연결 타임아웃과 읽기 타임아웃을 설정한 후 URLConnection을 반환합니다.
+     *
+     * @param url 연결할 URL 객체
+     * @return 설정된 타임아웃을 가진 URLConnection 객체
+     * @throws RuntimeException 연결 중 IOException이 발생할 경우 런타임 예외로 래핑하여 던짐
+     * @author 함예정
+     * @since 2025-05-12
+     */
+    private URLConnection openConnectionWithTimeout(URL url) {
+        try {
+            URLConnection connection = url.openConnection();
+            connection.setConnectTimeout(3000);
+            connection.setReadTimeout(5000);
+            return connection;
+        } catch (IOException e) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_CONNECTION_ERROR, e);
+        }
+    }
+
+    /**
+     * 주어진 URLConnection으로부터 RSS 피드를 읽어 SyndEntry 목록으로 파싱합니다.
+     *
+     * @param connection RSS 피드를 제공하는 URLConnection 객체
+     * @return 파싱된 SyndEntry 객체 리스트
+     * @throws ArticleCollectorException RSS 피드 파싱 중 오류가 발생한 경우 사용자 정의 예외로 래핑하여 던짐
+     * @author 함예정
+     * @since 2025-05-12
+     */
+    private List<SyndEntry> parseRssEntries(URLConnection connection) {
+        try (XmlReader reader = new XmlReader(connection)) {
+            SyndFeedInput input = new SyndFeedInput();
+            SyndFeed syndFeed = input.build(reader);
+            return syndFeed.getEntries();
+        } catch (Exception e) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_PARSING_ERROR, e);
+        }
+    }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssFeedReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/processor/RssFeedReader.java
@@ -4,38 +4,116 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.repository.RssNewsRepository;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.SyndFeedInput;
 import com.rometools.rome.io.XmlReader;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * RSS 피드 URL을 통해 XML 피드를 읽고 파싱하여 {@link SyndEntry} 목록으로 반환하는 Reader 클래스.
  * Rome 라이브러리를 이용하여 RSS를 파싱하며, 유효하지 않은 URL 또는 파싱 오류에 대해 예외를 처리한다.
  *
  * @since 2025-05-10
+ * @modified 2025-05-18 최신 발행일 이후 데이터만 필터링하는 기능 추가
  */
+@Slf4j
 @Component
 public class RssFeedReader {
+	private final RssNewsRepository rssNewsRepository;
+	private static final Map<String, LocalDateTime> lastProcessedDateMap = new ConcurrentHashMap<>();
+
+	@Autowired
+	public RssFeedReader(RssNewsRepository rssNewsRepository) {
+		this.rssNewsRepository = rssNewsRepository;
+	}
 
 	/**
-	 * 주어진 피드 URL로부터 RSS 피드를 파싱하고, {@link SyndEntry} 리스트를 반환한다.
+	 * 주어진 피드 URL로부터 RSS 피드를 파싱하고, 최신 발행일 이후의 {@link SyndEntry} 리스트를 반환한다.
 	 *
 	 * @param feedUrl RSS 피드의 URL 문자열
-	 * @return 파싱된 SyndEntry 목록
+	 * @param mapperType 매퍼 타입 (언론사 코드)
+	 * @return 파싱 및 필터링된 SyndEntry 목록
 	 * @since 2025-05-10
+	 * @modified 2025-05-18 최신 발행일 이후 데이터만 필터링하는 기능 추가
 	 * @author 함예정
 	 */
-	public List<SyndEntry> getFeed(String feedUrl) {
+	public List<SyndEntry> getFeed(String feedUrl, String mapperType) {
 		URL url = getURL(feedUrl);
 		URLConnection connection = openConnectionWithTimeout(url);
-		return parseRssEntries(connection);
+		List<SyndEntry> entries = parseRssEntries(connection);
+
+		LocalDateTime latestPubDate = getLatestPubDate(mapperType);
+
+		List<SyndEntry> filteredEntries = entries.stream()
+				.filter(entry -> isAfterLatestPubDate(entry, latestPubDate))
+				.collect(Collectors.toList());
+
+		return filteredEntries;
+	}
+
+	/**
+	 * 언론사별 최신 발행일 조회 (캐싱 추가)
+	 *
+	 * @param mapperType 매퍼 타입 (언론사 코드)
+	 * @return 최신 발행일 또는 기본값
+	 */
+	private LocalDateTime getLatestPubDate(String mapperType) {
+		String guidPrefix = mapperType.toUpperCase();
+
+		LocalDateTime latestPubDate = rssNewsRepository.findLatestPubDateByGuidPrefix(guidPrefix);
+
+		if (latestPubDate == null) {
+			latestPubDate = LocalDateTime.now().minusDays(1);
+		}
+
+		lastProcessedDateMap.put(mapperType, latestPubDate);
+		return latestPubDate;
+	}
+
+	/**
+	 * 항목의 발행일이 최신 발행일보다 이후인지 확인
+	 *
+	 * @param entry RSS 항목
+	 * @param latestPubDate 최신 발행일
+	 * @return 최신 발행일 이후면 true
+	 */
+	private boolean isAfterLatestPubDate(SyndEntry entry, LocalDateTime latestPubDate) {
+		if (entry.getPublishedDate() == null) {
+			log.debug("발행일 없음 - 항목 제외: {}", entry.getTitle());
+			return false;
+		}
+
+		LocalDateTime pubDate = convertToLocalDateTime(entry.getPublishedDate());
+
+		boolean isAfter = pubDate.isAfter(latestPubDate);
+
+		return isAfter;
+	}
+
+	/**
+	 * Date 객체를 LocalDateTime으로 변환
+	 *
+	 * @param date 변환할 Date 객체
+	 * @return 변환된 LocalDateTime
+	 */
+	private LocalDateTime convertToLocalDateTime(Date date) {
+		return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
 	}
 
 	/**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/reader/RssSourcePartitioner.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/reader/RssSourcePartitioner.java
@@ -14,112 +14,111 @@ import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.coll
 /**
  * 활성화된 RSS 소스를 파티션 단위로 분할하여 StepExecutionContext에 전달하는 Partitioner 구현체.
  * Spring Batch에서 멀티 스레드/병렬 실행을 위해 사용된다.
- *
+ * <p>
  * 각 파티션은 sourceList를 포함한 ExecutionContext로 구성된다.
  *
  * @since 2025-05-10
  */
 @Component
 public class RssSourcePartitioner implements Partitioner {
+    /**
+     * 전체 RSS 소스를 파티셔닝하여 각 파티션별 ExecutionContext를 생성한다.
+     * 모든 활성화된 RSS 소스(카테고리 포함)를 처리한다.
+     *
+     * @param gridSize 실행할 파티션 수
+     * @return 파티션 이름과 ExecutionContext의 매핑 정보
+     * @modified 2025-05-14 모든 카테고리 처리하도록 수정
+     * @author 함예정
+     * @since 2025-05-10
+     */
+    @Override
+    public Map<String, ExecutionContext> partition(int gridSize) {
+        List<RssSource> allSources = RssSource.getEnabledSources();
 
-	/**
-	 * 전체 RSS 소스를 파티셔닝하여 각 파티션별 ExecutionContext를 생성한다.
-	 * 모든 활성화된 RSS 소스(카테고리 포함)를 처리한다.
-	 *
-	 * @param gridSize 실행할 파티션 수
-	 * @return 파티션 이름과 ExecutionContext의 매핑 정보
-	 * @since 2025-05-10
-	 * @modified 2025-05-14 모든 카테고리 처리하도록 수정
-	 * @author 함예정
-	 */
-	@Override
-	public Map<String, ExecutionContext> partition(int gridSize) {
-		List<RssSource> allSources = RssSource.getEnabledSources();
+        int chunkSize = calculateChunkSize(allSources.size(), gridSize);
+        return buildPartitions(allSources, chunkSize);
+    }
 
-		int chunkSize = calculateChunkSize(allSources.size(), gridSize);
-		return buildPartitions(allSources, chunkSize);
-	}
+    /**
+     * 총 소스 수와 파티션 수를 기반으로 파티션당 소스 개수를 계산한다.
+     *
+     * @param totalSources 전체 RSS 소스 수
+     * @param gridSize     파티션 수
+     * @return 파티션당 소스 개수
+     * @since 2025-05-10
+     */
+    private int calculateChunkSize(int totalSources, int gridSize) {
+        int chunkSize = (int) Math.ceil((double) totalSources / gridSize);
+        return chunkSize;
+    }
 
-	/**
-	 * 총 소스 수와 파티션 수를 기반으로 파티션당 소스 개수를 계산한다.
-	 *
-	 * @param totalSources 전체 RSS 소스 수
-	 * @param gridSize 파티션 수
-	 * @return 파티션당 소스 개수
-	 * @since 2025-05-10
-	 */
-	private int calculateChunkSize(int totalSources, int gridSize) {
-		int chunkSize = (int)Math.ceil((double)totalSources / gridSize);
-		return chunkSize;
-	}
+    /**
+     * RSS 소스를 주어진 chunkSize로 나눠 각 파티션별 ExecutionContext를 생성한다.
+     *
+     * @param sources   RSS 소스 리스트
+     * @param chunkSize 파티션당 소스 개수
+     * @return 파티션 맵
+     * @since 2025-05-10
+     */
+    private Map<String, ExecutionContext> buildPartitions(List<RssSource> sources, int chunkSize) {
+        Map<String, ExecutionContext> partitions = new HashMap<>();
+        int totalPartitions = calculateTotalPartitions(sources, chunkSize);
 
-	/**
-	 * RSS 소스를 주어진 chunkSize로 나눠 각 파티션별 ExecutionContext를 생성한다.
-	 *
-	 * @param sources RSS 소스 리스트
-	 * @param chunkSize 파티션당 소스 개수
-	 * @return 파티션 맵
-	 * @since 2025-05-10
-	 */
-	private Map<String, ExecutionContext> buildPartitions(List<RssSource> sources, int chunkSize) {
-		Map<String, ExecutionContext> partitions = new HashMap<>();
-		int totalPartitions = calculateTotalPartitions(sources, chunkSize);
+        for (int i = 0; i < totalPartitions; i++) {
+            int from = i * chunkSize;
+            int to = calculateChunkEndIndex(sources, chunkSize, from);
 
-		for (int i = 0; i < totalPartitions; i++) {
-			int from = i * chunkSize;
-			int to = calculateChunkEndIndex(sources, chunkSize, from);
+            if (from >= to) {
+                break;
+            }
 
-			if (from >= to) {
-				break;
-			}
+            ExecutionContext context = buildExecutionContext(sources, from, to);
+            partitions.put("partition" + i, context);
+        }
 
-			ExecutionContext context = buildExecutionContext(sources, from, to);
-			partitions.put("partition" + i, context);
-		}
+        return partitions;
+    }
 
-		return partitions;
-	}
+    /**
+     * 주어진 RSS 소스 리스트를 청크 크기(chunkSize)로 분할할 때 필요한 총 파티션 수를 계산합니다.
+     *
+     * @param sources   RSS 소스 목록
+     * @param chunkSize 하나의 파티션에 포함될 RSS 소스 수
+     * @return 전체 파티션 수
+     * @since 2025-05-12
+     */
+    private int calculateTotalPartitions(List<RssSource> sources, int chunkSize) {
+        return (sources.size() + chunkSize - 1) / chunkSize;
+    }
 
-	/**
-	 * 주어진 RSS 소스 리스트를 청크 크기(chunkSize)로 분할할 때 필요한 총 파티션 수를 계산합니다.
-	 *
-	 * @param sources RSS 소스 목록
-	 * @param chunkSize 하나의 파티션에 포함될 RSS 소스 수
-	 * @return 전체 파티션 수
-	 * @since 2025-05-12
-	 */
-	private int calculateTotalPartitions(List<RssSource> sources, int chunkSize) {
-		return (sources.size() + chunkSize - 1) / chunkSize;
-	}
+    /**
+     * 주어진 시작 인덱스(from)와 청크 크기(chunkSize)를 기반으로,
+     * 리스트의 범위를 초과하지 않도록 제한된 끝 인덱스를 계산합니다.
+     *
+     * @param sources   RSS 소스 리스트
+     * @param chunkSize 하나의 파티션에 포함될 RSS 소스 수
+     * @param from      시작 인덱스
+     * @return 리스트 범위를 초과하지 않는 끝 인덱스
+     * @since 2025-05-12
+     */
+    private int calculateChunkEndIndex(List<RssSource> sources, int chunkSize, int from) {
+        return Math.min(from + chunkSize, sources.size());
+    }
 
-	/**
-	 * 주어진 시작 인덱스(from)와 청크 크기(chunkSize)를 기반으로,
-	 * 리스트의 범위를 초과하지 않도록 제한된 끝 인덱스를 계산합니다.
-	 *
-	 * @param sources RSS 소스 리스트
-	 * @param chunkSize 하나의 파티션에 포함될 RSS 소스 수
-	 * @param from 시작 인덱스
-	 * @return 리스트 범위를 초과하지 않는 끝 인덱스
-	 * @since 2025-05-12
-	 */
-	private int calculateChunkEndIndex(List<RssSource> sources, int chunkSize, int from) {
-		return Math.min(from + chunkSize, sources.size());
-	}
-
-	/**
-	 * 지정된 인덱스 범위에 해당하는 RSS 소스 부분 리스트로 ExecutionContext를 생성한다.
-	 * 생성된 context는 Spring Batch 파티션 실행 시 각 Step에 전달된다.
-	 *
-	 * @param sources 전체 RSS 소스 리스트
-	 * @param from 시작 인덱스 (포함)
-	 * @param to 종료 인덱스 (미포함)
-	 * @return 파티션별 RSS 소스가 포함된 ExecutionContext
-	 * @since 2025-05-10
-	 */
-	private ExecutionContext buildExecutionContext(List<RssSource> sources, int from, int to) {
-		List<RssSource> subList = new ArrayList<>(sources.subList(from, to));
-		ExecutionContext context = new ExecutionContext();
-		context.put("sourceList", subList);
-		return context;
-	}
+    /**
+     * 지정된 인덱스 범위에 해당하는 RSS 소스 부분 리스트로 ExecutionContext를 생성한다.
+     * 생성된 context는 Spring Batch 파티션 실행 시 각 Step에 전달된다.
+     *
+     * @param sources 전체 RSS 소스 리스트
+     * @param from    시작 인덱스 (포함)
+     * @param to      종료 인덱스 (미포함)
+     * @return 파티션별 RSS 소스가 포함된 ExecutionContext
+     * @since 2025-05-10
+     */
+    private ExecutionContext buildExecutionContext(List<RssSource> sources, int from, int to) {
+        List<RssSource> subList = new ArrayList<>(sources.subList(from, to));
+        ExecutionContext context = new ExecutionContext();
+        context.put("sourceList", subList);
+        return context;
+    }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/AbstractRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/AbstractRssMapper.java
@@ -41,10 +41,17 @@ public abstract class AbstractRssMapper {
         String guid = extractGuid(entry, source);
         String description = extractDescription(entry);
         String category = extractCategory(entry, source);
+        String imageUrl = extractImageUrl(entry);
 
-        String content = getContentWithScraping(description, link, source.getMapperType());
+        // 본문 내용 결정
+        String content = description;
 
-        return buildArticleEntity(title, link, pubDate, guid, description, category);
+        // RSS가 전체 내용을 포함하지 않는 경우에만 스크래핑 시도
+        if (!source.hasFullContent()) {
+            content = getContentWithScraping(description, link, source.getMapperType());
+        }
+
+        return buildArticleEntity(title, link, pubDate, guid, content, category, imageUrl);
     }
 
     /**
@@ -103,6 +110,17 @@ public abstract class AbstractRssMapper {
     }
 
     /**
+     * 이미지 URL 추출 메서드
+     * 기본 구현은 빈 문자열 반환, 이미지 URL을 제공하는 매퍼에서 오버라이드해야 함
+     *
+     * @param entry RSS 항목
+     * @return 이미지 URL
+     */
+    protected String extractImageUrl(SyndEntry entry) {
+        return "";
+    }
+
+    /**
      * 본문 내용을 가져오는 메서드
      * 스크래퍼가 있으면 스크래핑을 시도하고, 실패하면 원본 description 사용
      *
@@ -150,18 +168,8 @@ public abstract class AbstractRssMapper {
      */
     protected abstract String extractGuid(SyndEntry entry, RssSource source);
 
-    /**
-     * 뉴스 요약 여부 반환
-     * Default true를 반환, false 사용시 각 뉴스 Mapper에서 오버라이드해야 함
-     *
-     * @return 요약본 여부
-     */
-    protected boolean getIsSummary() {
-        return true;
-    }
-
     private ArticleEntity buildArticleEntity(String title, String link, LocalDateTime pubDate,
-                                             String guid, String description, String category) {
+                                             String guid, String description, String category, String imageUrl) {
         return ArticleEntity.builder()
                 .title(title)
                 .link(link)
@@ -169,7 +177,7 @@ public abstract class AbstractRssMapper {
                 .category(category)
                 .guid(guid)
                 .description(description)
-                .isSummary(getIsSummary())
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
@@ -78,21 +78,4 @@ public class DongaRssMapper extends AbstractRssMapper {
     protected String extractCategory(SyndEntry entry, RssSource source) {
         return source.getCategoryName();
     }
-
-    /**
-     * 이미지 URL 추출 메서드
-     * 동아일보 RSS feed에서 media:content 태그에서 이미지 URL 추출
-     *
-     * @param entry RSS 항목
-     * @return 이미지 URL
-     */
-    @Override
-    protected String extractImageUrl(SyndEntry entry) {
-        return entry.getForeignMarkup().stream()
-                .filter(element -> "content".equals(element.getName()) &&
-                        "media".equals(element.getNamespacePrefix()))
-                .findFirst()
-                .map(element -> element.getAttributeValue("url"))
-                .orElse("");
-    }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
@@ -1,5 +1,7 @@
 package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.implement;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.config.batch.RssSource;
@@ -10,15 +12,23 @@ import com.rometools.rome.feed.synd.SyndEntry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * 동아일보 RSS 매퍼 구현체
  *
  * @author 양병학
  * @since 2025-05-10 최초 작성
  * @modified 2025-05-15 템플릿 메서드 패턴 적용, 의존성 주입 방식 개선
+ * @modified 2025-05-17 HTML 태그 제거 및 문단 직렬화 기능 추가
  */
 @Component
 public class DongaRssMapper extends AbstractRssMapper {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final ScraperFactory scraperFactory;
 
@@ -85,7 +95,7 @@ public class DongaRssMapper extends AbstractRssMapper {
     }
 
     /**
-     * 카테고리 enum 정보 추출
+     * 카테고리 정보 추출
      *
      * @param entry RSS 항목
      * @param source RSS 소스 정보
@@ -94,5 +104,113 @@ public class DongaRssMapper extends AbstractRssMapper {
     @Override
     protected String extractCategory(SyndEntry entry, RssSource source) {
         return source.getCategoryName();
+    }
+
+    /**
+     * RSS description에서 HTML 태그를 제거하고 문단을 추출하여 직렬화
+     *
+     * @param entry RSS 항목
+     * @return 직렬화된 문단 JSON 또는 원본 description
+     */
+    @Override
+    protected String extractDescription(SyndEntry entry) {
+        if (entry.getDescription() == null) {
+            return "";
+        }
+
+        String rawDescription = entry.getDescription().getValue();
+        if (rawDescription == null || rawDescription.isEmpty()) {
+            return "";
+        }
+
+        return processHtmlContent(rawDescription);
+    }
+
+    /**
+     * HTML 콘텐츠 처리하여 정제된 문단 직렬화
+     *
+     * @param htmlContent HTML 콘텐츠
+     * @return 직렬화된 문단 JSON 또는 태그가 제거된 텍스트
+     */
+    private String processHtmlContent(String htmlContent) {
+        try {
+            List<String> paragraphs = extractCleanParagraphs(htmlContent);
+            return serializeParagraphs(paragraphs);
+        } catch (Exception e) {
+            return removeAllHtmlTags(htmlContent);
+        }
+    }
+
+    /**
+     * HTML 문자열에서 모든 태그를 제거하고 문단을 추출하는 메서드
+     *
+     * @param html HTML 문자열
+     * @return 정제된 문단 리스트
+     */
+    private List<String> extractCleanParagraphs(String html) {
+        if (html == null || html.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        try {
+            String withBreaks = html.replaceAll("<br\\s*/?>", "PARAGRAPH_BREAK");
+            String noTags = withBreaks.replaceAll("<[^>]*>", "");
+            String decoded = noTags.replace("&nbsp;", " ")
+                    .replace("&#160;", " ")
+                    .replace("&lt;", "<")
+                    .replace("&gt;", ">")
+                    .replace("&amp;", "&")
+                    .replace("&quot;", "\"")
+                    .replace("&apos;", "'");
+
+            decoded = decoded.replaceAll("\\s+", " ").trim();
+            String[] paragraphs = decoded.split("PARAGRAPH_BREAK");
+
+            return Arrays.stream(paragraphs)
+                    .map(String::trim)
+                    .filter(p -> !p.isEmpty())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            List<String> fallback = new ArrayList<>();
+            fallback.add(removeAllHtmlTags(html));
+            return fallback;
+        }
+    }
+
+    /**
+     * 모든 HTML 태그 제거
+     *
+     * @param html HTML 문자열
+     * @return 태그가 제거된 문자열
+     */
+    private String removeAllHtmlTags(String html) {
+        if (html == null || html.isEmpty()) {
+            return "";
+        }
+
+        String noTags = html.replaceAll("<[^>]*>", "");
+        String decoded = noTags.replace("&nbsp;", " ")
+                .replace("&#160;", " ")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&")
+                .replace("&quot;", "\"")
+                .replace("&apos;", "'");
+
+        return decoded.replaceAll("\\s+", " ").trim();
+    }
+
+    /**
+     * 문단 리스트를 JSON으로 직렬화
+     *
+     * @param paragraphs 문단 리스트
+     * @return JSON 문자열
+     */
+    private String serializeParagraphs(List<String> paragraphs) {
+        try {
+            return objectMapper.writeValueAsString(paragraphs);
+        } catch (JsonProcessingException e) {
+            return String.join("\n\n", paragraphs);
+        }
     }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
@@ -78,4 +78,21 @@ public class DongaRssMapper extends AbstractRssMapper {
     protected String extractCategory(SyndEntry entry, RssSource source) {
         return source.getCategoryName();
     }
+
+    /**
+     * 이미지 URL 추출 메서드
+     * 동아일보 RSS feed에서 media:content 태그에서 이미지 URL 추출
+     *
+     * @param entry RSS 항목
+     * @return 이미지 URL
+     */
+    @Override
+    protected String extractImageUrl(SyndEntry entry) {
+        return entry.getForeignMarkup().stream()
+                .filter(element -> "content".equals(element.getName()) &&
+                        "media".equals(element.getNamespacePrefix()))
+                .findFirst()
+                .map(element -> element.getAttributeValue("url"))
+                .orElse("");
+    }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
@@ -28,8 +28,6 @@ import java.util.stream.Collectors;
 @Component
 public class DongaRssMapper extends AbstractRssMapper {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     private final ScraperFactory scraperFactory;
 
     @Autowired
@@ -138,79 +136,6 @@ public class DongaRssMapper extends AbstractRssMapper {
             return serializeParagraphs(paragraphs);
         } catch (Exception e) {
             return removeAllHtmlTags(htmlContent);
-        }
-    }
-
-    /**
-     * HTML 문자열에서 모든 태그를 제거하고 문단을 추출하는 메서드
-     *
-     * @param html HTML 문자열
-     * @return 정제된 문단 리스트
-     */
-    private List<String> extractCleanParagraphs(String html) {
-        if (html == null || html.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        try {
-            String withBreaks = html.replaceAll("<br\\s*/?>", "PARAGRAPH_BREAK");
-            String noTags = withBreaks.replaceAll("<[^>]*>", "");
-            String decoded = noTags.replace("&nbsp;", " ")
-                    .replace("&#160;", " ")
-                    .replace("&lt;", "<")
-                    .replace("&gt;", ">")
-                    .replace("&amp;", "&")
-                    .replace("&quot;", "\"")
-                    .replace("&apos;", "'");
-
-            decoded = decoded.replaceAll("\\s+", " ").trim();
-            String[] paragraphs = decoded.split("PARAGRAPH_BREAK");
-
-            return Arrays.stream(paragraphs)
-                    .map(String::trim)
-                    .filter(p -> !p.isEmpty())
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            List<String> fallback = new ArrayList<>();
-            fallback.add(removeAllHtmlTags(html));
-            return fallback;
-        }
-    }
-
-    /**
-     * 모든 HTML 태그 제거
-     *
-     * @param html HTML 문자열
-     * @return 태그가 제거된 문자열
-     */
-    private String removeAllHtmlTags(String html) {
-        if (html == null || html.isEmpty()) {
-            return "";
-        }
-
-        String noTags = html.replaceAll("<[^>]*>", "");
-        String decoded = noTags.replace("&nbsp;", " ")
-                .replace("&#160;", " ")
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&amp;", "&")
-                .replace("&quot;", "\"")
-                .replace("&apos;", "'");
-
-        return decoded.replaceAll("\\s+", " ").trim();
-    }
-
-    /**
-     * 문단 리스트를 JSON으로 직렬화
-     *
-     * @param paragraphs 문단 리스트
-     * @return JSON 문자열
-     */
-    private String serializeParagraphs(List<String> paragraphs) {
-        try {
-            return objectMapper.writeValueAsString(paragraphs);
-        } catch (JsonProcessingException e) {
-            return String.join("\n\n", paragraphs);
         }
     }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
@@ -65,10 +65,11 @@ public class DongaRssMapper extends AbstractRssMapper {
      *
      * @param link 기사 링크
      * @return 추출된 고유 ID
+     * @throws ArticleCollectorException 링크가 null이거나 ID를 추출할 수 없는 경우
      */
     private String extractUniqueIdFromLink(String link) {
-        if (link == null) {
-            return String.valueOf(System.currentTimeMillis());
+        if (link == null || link.trim().isEmpty()) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
         }
 
         try {
@@ -77,10 +78,10 @@ public class DongaRssMapper extends AbstractRssMapper {
                 return parts[parts.length - 2];
             }
         } catch (Exception e) {
-            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR, e);
         }
 
-        return String.valueOf(System.currentTimeMillis());
+        throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/DongaRssMapper.java
@@ -4,22 +4,38 @@ import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCo
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.config.batch.RssSource;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.AbstractRssMapper;
-import com.rometools.rome.feed.synd.SyndCategory;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.factory.ScraperFactory;
 import com.rometools.rome.feed.synd.SyndEntry;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.stream.Collectors;
 
 /**
  * 동아일보 RSS 매퍼 구현체
  *
  * @author 양병학
  * @since 2025-05-10 최초 작성
- * @modified 2025-05-13 AbstractRssMapper 상속 구조로 변경 및 활성화
+ * @modified 2025-05-15 템플릿 메서드 패턴 적용, 의존성 주입 방식 개선
  */
 @Component
 public class DongaRssMapper extends AbstractRssMapper {
+
+    private final ScraperFactory scraperFactory;
+
+    @Autowired
+    public DongaRssMapper(ScraperFactory scraperFactory) {
+        this.scraperFactory = scraperFactory;
+    }
+
+    /**
+     * 템플릿 메서드 패턴
+     *
+     * @return 주입받은 ScraperFactory 인스턴스
+     */
+    @Override
+    protected ScraperFactory getScraperFactory() {
+        return this.scraperFactory;
+    }
 
     /**
      * 매퍼 타입 반환

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KhanRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KhanRssMapper.java
@@ -67,24 +67,28 @@ public class KhanRssMapper extends AbstractRssMapper {
      *
      * @param link 기사 링크
      * @return 추출된 고유 ID
+     * @throws ArticleCollectorException 링크가 null이거나 ID를 추출할 수 없는 경우
      */
     private String extractUniqueIdFromLink(String link) {
-        if (link == null) {
-            return String.valueOf(System.currentTimeMillis());
+        if (link == null || link.trim().isEmpty()) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
         }
 
         try {
             String[] parts = link.split("/");
             for (int i = 0; i < parts.length; i++) {
                 if ("article".equals(parts[i]) && i + 1 < parts.length) {
-                    return parts[i + 1];
+                    String id = parts[i + 1];
+                    if (id != null && !id.trim().isEmpty()) {
+                        return id;
+                    }
                 }
             }
         } catch (Exception e) {
-            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR, e);
         }
 
-        return String.valueOf(System.currentTimeMillis());
+        throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KhanRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KhanRssMapper.java
@@ -1,16 +1,24 @@
 package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.implement;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.config.batch.RssSource;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.AbstractRssMapper;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.ContentScraper;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.factory.ScraperFactory;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
 import com.rometools.rome.feed.synd.SyndEntry;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * 경향신문 RSS 매퍼 구현체
@@ -18,9 +26,12 @@ import java.time.LocalDateTime;
  * @author 양병학
  * @since 2025-05-10 최초 작성
  * @modified 2025-05-15 템플릿 메서드 패턴 적용, 의존성 주입 방식 개선
+ * @modified 2025-05-17 mapToRssNews 메서드 오버라이드 및 문단 직렬화 기능 추가
  */
 @Component
 public class KhanRssMapper extends AbstractRssMapper {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final ScraperFactory scraperFactory;
 
@@ -37,6 +48,95 @@ public class KhanRssMapper extends AbstractRssMapper {
     @Override
     protected ScraperFactory getScraperFactory() {
         return this.scraperFactory;
+    }
+
+    /**
+     * RSS 피드를 ArticleEntity 엔티티로 변환 (오버라이드)
+     * 경향신문 특화 구현 - 본문과 이미지 URL을 효율적으로 스크래핑하고 문단 직렬화
+     *
+     * @param entry 변환할 SyndEntry(Rss 데이터) 객체
+     * @param source RSS 소스 정보
+     * @return 변환된 ArticleEntity 엔티티
+     */
+    @Override
+    public ArticleEntity mapToRssNews(SyndEntry entry, RssSource source) {
+        String title = extractTitle(entry);
+        String link = extractLink(entry);
+        LocalDateTime pubDate = extractPubDate(entry);
+        String guid = extractGuid(entry, source);
+        String description = extractDescription(entry);
+        String category = extractCategory(entry, source);
+        String imageUrl = super.extractImageUrl(entry);
+
+        ContentResult contentResult;
+        if (source.hasFullContent()) {
+            contentResult = new ContentResult(description, imageUrl);
+        } else {
+            contentResult = scrapeContentAndImage(link, description, imageUrl);
+        }
+
+        return ArticleEntity.builder()
+                .title(title)
+                .link(link)
+                .pubDate(pubDate)
+                .category(category)
+                .guid(guid)
+                .description(contentResult.getContent())
+                .imageUrl(contentResult.getImageUrl())
+                .build();
+    }
+
+    /**
+     * 본문과 이미지 URL을 스크래핑하고 처리하는 메서드
+     *
+     * @param link 기사 URL
+     * @param fallbackDescription 스크래핑 실패 시 사용할 설명
+     * @param fallbackImageUrl 스크래핑 실패 시 사용할 이미지 URL
+     * @return 처리된 콘텐츠와 이미지 URL이 포함된 결과 객체
+     */
+    private ContentResult scrapeContentAndImage(String link, String fallbackDescription, String fallbackImageUrl) {
+        try {
+            ContentScraper scraper = getScraperFactory().getScraper(getMapperType())
+                    .orElseThrow(() -> new ArticleCollectorException(ArticleCollectorErrorCode.MAPPER_NOT_FOUND));
+
+            String content = fallbackDescription;
+            String scrapedContent = scraper.scrapeContent(link);
+            if (scrapedContent != null && !scrapedContent.isEmpty()) {
+                List<String> paragraphs = Arrays.asList(scrapedContent.split("\n\n"));
+                content = serializeParagraphs(paragraphs);
+            }
+
+            String imageUrl = fallbackImageUrl;
+            if (imageUrl == null || imageUrl.isEmpty()) {
+                imageUrl = scraper.scrapeImageUrl(link);
+            }
+
+            return new ContentResult(content, imageUrl);
+        } catch (Exception e) {
+            System.err.println("경향신문 스크래핑 실패: " + e.getMessage());
+            return new ContentResult(fallbackDescription, fallbackImageUrl);
+        }
+    }
+
+    /**
+     * 콘텐츠 결과를 담는 내부 클래스
+     */
+    private static class ContentResult {
+        private final String content;
+        private final String imageUrl;
+
+        public ContentResult(String content, String imageUrl) {
+            this.content = content;
+            this.imageUrl = imageUrl;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public String getImageUrl() {
+            return imageUrl;
+        }
     }
 
     /**
@@ -136,7 +236,7 @@ public class KhanRssMapper extends AbstractRssMapper {
     }
 
     /**
-     * 카테고리 enum 정보 추출
+     * 카테고리 정보 추출
      *
      * @param entry RSS 항목
      * @param source RSS 소스 정보
@@ -145,5 +245,78 @@ public class KhanRssMapper extends AbstractRssMapper {
     @Override
     protected String extractCategory(SyndEntry entry, RssSource source) {
         return source.getCategoryName();
+    }
+
+    /**
+     * 문단 리스트를 JSON으로 직렬화
+     *
+     * @param paragraphs 문단 리스트
+     * @return JSON 문자열
+     */
+    private String serializeParagraphs(List<String> paragraphs) {
+        try {
+            return objectMapper.writeValueAsString(paragraphs);
+        } catch (JsonProcessingException e) {
+            return String.join("\n\n", paragraphs);
+        }
+    }
+
+    /**
+     * HTML 문자열에서 모든 태그를 제거하고 문단을 추출하는 메서드
+     *
+     * @param html HTML 문자열
+     * @return 정제된 문단 리스트
+     */
+    private List<String> extractCleanParagraphs(String html) {
+        if (html == null || html.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        try {
+            String withBreaks = html.replaceAll("<br\\s*/?>", "PARAGRAPH_BREAK");
+            String noTags = withBreaks.replaceAll("<[^>]*>", "");
+            String decoded = noTags.replace("&nbsp;", " ")
+                    .replace("&#160;", " ")
+                    .replace("&lt;", "<")
+                    .replace("&gt;", ">")
+                    .replace("&amp;", "&")
+                    .replace("&quot;", "\"")
+                    .replace("&apos;", "'");
+
+            decoded = decoded.replaceAll("\\s+", " ").trim();
+            String[] paragraphs = decoded.split("PARAGRAPH_BREAK");
+
+            return Arrays.stream(paragraphs)
+                    .map(String::trim)
+                    .filter(p -> !p.isEmpty())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            List<String> fallback = new ArrayList<>();
+            fallback.add(removeAllHtmlTags(html));
+            return fallback;
+        }
+    }
+
+    /**
+     * 모든 HTML 태그 제거
+     *
+     * @param html HTML 문자열
+     * @return 태그가 제거된 문자열
+     */
+    private String removeAllHtmlTags(String html) {
+        if (html == null || html.isEmpty()) {
+            return "";
+        }
+
+        String noTags = html.replaceAll("<[^>]*>", "");
+        String decoded = noTags.replace("&nbsp;", " ")
+                .replace("&#160;", " ")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&amp;", "&")
+                .replace("&quot;", "\"")
+                .replace("&apos;", "'");
+
+        return decoded.replaceAll("\\s+", " ").trim();
     }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KhanRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KhanRssMapper.java
@@ -4,23 +4,40 @@ import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCo
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.config.batch.RssSource;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.AbstractRssMapper;
-import com.rometools.rome.feed.synd.SyndCategory;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.factory.ScraperFactory;
 import com.rometools.rome.feed.synd.SyndEntry;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.stream.Collectors;
 
 /**
  * 경향신문 RSS 매퍼 구현체
  *
  * @author 양병학
  * @since 2025-05-10 최초 작성
- * @modified 2025-05-13 AbstractRssMapper 상속 구조로 변경 및 활성화
+ * @modified 2025-05-15 템플릿 메서드 패턴 적용, 의존성 주입 방식 개선
  */
 @Component
 public class KhanRssMapper extends AbstractRssMapper {
+
+    private final ScraperFactory scraperFactory;
+
+    @Autowired
+    public KhanRssMapper(ScraperFactory scraperFactory) {
+        this.scraperFactory = scraperFactory;
+    }
+
+    /**
+     * 템플릿 메서드 패턴
+     *
+     * @return 주입받은 ScraperFactory 인스턴스
+     */
+    @Override
+    protected ScraperFactory getScraperFactory() {
+        return this.scraperFactory;
+    }
 
     /**
      * 매퍼 타입 반환
@@ -64,14 +81,14 @@ public class KhanRssMapper extends AbstractRssMapper {
                 }
             }
         } catch (Exception e) {
-        throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
-    }
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
+        }
 
         return String.valueOf(System.currentTimeMillis());
     }
 
     /**
-     * 발행일 추출, 경향신문은 dc:date 태그도 확인
+     * 발행일 추출, 경향신문은 dc:date 태그 확인
      *
      * @param entry RSS 항목
      * @return 발행일 LocalDateTime
@@ -86,7 +103,7 @@ public class KhanRssMapper extends AbstractRssMapper {
     }
 
     /**
-     * Dublin Core date 태그에서 발행일 추출
+     * date 태그에서 발행일 추출
      *
      * @param entry RSS 항목
      * @return 추출된 발행일, 없으면 현재 시간

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
@@ -24,7 +24,9 @@ import java.util.regex.Pattern;
 public class KmibRssMapper extends AbstractRssMapper {
 
     private static final Pattern ARCID_PATTERN = Pattern.compile("arcid=([0-9]+)");
-    private static final Pattern IMG_SRC_PATTERN = Pattern.compile("<img\\s+src=[\"']([^\"']+)[\"']");
+    private static final Pattern IMG_SRC_PATTERN = Pattern.compile("""
+    <img\\s+src=["']([^"']+)["']
+    """.trim());
 
     private final ScraperFactory scraperFactory;
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
@@ -47,17 +47,6 @@ public class KmibRssMapper extends AbstractRssMapper {
     }
 
     /**
-     * Rss 피드가 요약본인지 여부를 반환
-     * 국민일보는 RSS에 전체 내용이 포함, false 반환
-     *
-     * @return 요약본 여부 (false: 전체 본문 제공)
-     */
-    @Override
-    protected boolean getIsSummary() {
-        return false;
-    }
-
-    /**
      * 링크에서 arcid 값 추출
      *
      * @param link 기사 링크
@@ -73,5 +62,22 @@ public class KmibRssMapper extends AbstractRssMapper {
             return matcher.group(1);
         }
         return link;
+    }
+
+    /**
+     * 이미지 URL 추출 메서드
+     * 국민일보 RSS feed에서 media:content 태그에서 이미지 URL 추출
+     *
+     * @param entry RSS 항목
+     * @return 이미지 URL
+     */
+    @Override
+    protected String extractImageUrl(SyndEntry entry) {
+        return entry.getForeignMarkup().stream()
+                .filter(element -> "content".equals(element.getName()) &&
+                        "media".equals(element.getNamespacePrefix()))
+                .findFirst()
+                .map(element -> element.getAttributeValue("url"))
+                .orElse("");
     }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
@@ -81,17 +81,20 @@ public class KmibRssMapper extends AbstractRssMapper {
      * @return 추출된 arcid, 없으면 타임스탬프 반환
      */
     private String extractArcIdFromLink(String link) {
-        if (link == null) {
-            return String.valueOf(System.currentTimeMillis());
+        if (link == null || link.trim().isEmpty()) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
         }
 
         Matcher matcher = ARCID_PATTERN.matcher(link);
         if (matcher.find()) {
-            return matcher.group(1);
+            String arcId = matcher.group(1);
+            if (arcId != null && !arcId.trim().isEmpty()) {
+                return arcId;
+            }
         }
 
-        // 패턴이 일치하지 않는 경우도 타임스탬프 반환
-        return String.valueOf(System.currentTimeMillis());
+        // 패턴이 일치하지 않는 경우 예외 발생
+        throw new ArticleCollectorException(ArticleCollectorErrorCode.ITEM_MAPPING_ERROR);
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
@@ -2,10 +2,12 @@ package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.col
 
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.config.batch.RssSource;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.AbstractRssMapper;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
 import com.rometools.rome.feed.synd.SyndEntry;
 
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,6 +44,17 @@ public class KmibRssMapper extends AbstractRssMapper {
     protected String extractGuid(SyndEntry entry, RssSource source) {
         String arcId = extractArcIdFromLink(entry.getLink());
         return source.getCodePrefix() + arcId;
+    }
+
+    /**
+     * Rss 피드가 요약본인지 여부를 반환
+     * 국민일보는 RSS에 전체 내용이 포함, false 반환
+     *
+     * @return 요약본 여부 (false: 전체 본문 제공)
+     */
+    @Override
+    protected boolean getIsSummary() {
+        return false;
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
@@ -35,8 +35,6 @@ public class KmibRssMapper extends AbstractRssMapper {
     <img\\s+src=["']([^"']+)["']
     """.trim());
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     private final ScraperFactory scraperFactory;
 
     @Autowired
@@ -166,83 +164,6 @@ public class KmibRssMapper extends AbstractRssMapper {
             return serializeParagraphs(paragraphs);
         } catch (Exception e) {
             return removeAllHtmlTags(rawDescription);
-        }
-    }
-
-    /**
-     * HTML 문자열에서 모든 태그를 제거하고 문단을 추출하는 메서드
-     *
-     * @param html HTML 문자열
-     * @return 정제된 문단 리스트
-     */
-    private List<String> extractCleanParagraphs(String html) {
-        if (html == null || html.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        try {
-            String withBreaks = html.replaceAll("<br\\s*/?>", "PARAGRAPH_BREAK");
-
-            String noTags = withBreaks.replaceAll("<[^>]*>", "");
-
-            String decoded = noTags.replace("&nbsp;", " ")
-                    .replace("&#160;", " ")
-                    .replace("&lt;", "<")
-                    .replace("&gt;", ">")
-                    .replace("&amp;", "&")
-                    .replace("&quot;", "\"")
-                    .replace("&apos;", "'");
-
-            decoded = decoded.replaceAll("\\s+", " ").trim();
-
-            String[] paragraphs = decoded.split("PARAGRAPH_BREAK");
-
-            return Arrays.stream(paragraphs)
-                    .map(String::trim)
-                    .filter(p -> !p.isEmpty())
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            List<String> fallback = new ArrayList<>();
-            fallback.add(removeAllHtmlTags(html));
-            return fallback;
-        }
-    }
-
-    /**
-     * 모든 HTML 태그 제거
-     *
-     * @param html HTML 문자열
-     * @return 태그가 제거된 문자열
-     */
-    private String removeAllHtmlTags(String html) {
-        if (html == null || html.isEmpty()) {
-            return "";
-        }
-
-        String noTags = html.replaceAll("<[^>]*>", "");
-
-        String decoded = noTags.replace("&nbsp;", " ")
-                .replace("&#160;", " ")
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&amp;", "&")
-                .replace("&quot;", "\"")
-                .replace("&apos;", "'");
-
-        return decoded.replaceAll("\\s+", " ").trim();
-    }
-
-    /**
-     * 문단 리스트를 JSON으로 직렬화
-     *
-     * @param paragraphs 문단 리스트
-     * @return JSON 문자열
-     */
-    private String serializeParagraphs(List<String> paragraphs) {
-        try {
-            return objectMapper.writeValueAsString(paragraphs);
-        } catch (JsonProcessingException e) {
-            return String.join("\n\n", paragraphs);
         }
     }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/mapper/implement/KmibRssMapper.java
@@ -4,12 +4,12 @@ import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCo
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.config.batch.RssSource;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.mapper.AbstractRssMapper;
-import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.factory.ScraperFactory;
 import com.rometools.rome.feed.synd.SyndEntry;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,13 +18,30 @@ import java.util.regex.Pattern;
  *
  * @author 양병학
  * @since 2025-05-10 최초 작성
- * @modified 2025-05-13 AbstractRssMapper 상속 구조로 변경
+ * @modified 2025-05-15 템플릿 메서드 패턴 적용, 의존성 주입 방식 개선
  */
 @Component
 public class KmibRssMapper extends AbstractRssMapper {
 
     private static final Pattern ARCID_PATTERN = Pattern.compile("arcid=([0-9]+)");
     private static final Pattern IMG_SRC_PATTERN = Pattern.compile("<img\\s+src=[\"']([^\"']+)[\"']");
+
+    private final ScraperFactory scraperFactory;
+
+    @Autowired
+    public KmibRssMapper(ScraperFactory scraperFactory) {
+        this.scraperFactory = scraperFactory;
+    }
+
+    /**
+     * 템플릿 메서드 패턴
+     *
+     * @return 주입받은 ScraperFactory 인스턴스
+     */
+    @Override
+    protected ScraperFactory getScraperFactory() {
+        return this.scraperFactory;
+    }
 
     /**
      * 매퍼 타입 반환

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/ContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/ContentScraper.java
@@ -1,0 +1,26 @@
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper;
+
+/**
+ * 뉴스 본문 스크랩 interface
+ * 스크래핑 로직이 신문사 마다 다름
+ *
+ * @author 양병학
+ * @since 2025-05-13 최초 작성
+ */
+public interface ContentScraper {
+
+    /**
+     * 뉴스 URL에서 본문 내용을 스크래핑
+     *
+     * @param url 뉴스 URL
+     * @return 스크래핑된 본문
+     */
+    String scrapeContent(String url);
+
+    /**
+     * 스크래퍼가 지원하는 Mapper type 반환
+     *
+     * @return 지원하는 Mapper Type 영문 2자 (예: "km", "da")
+     */
+    String getSupportedMapperType();
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/ContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/ContentScraper.java
@@ -1,7 +1,11 @@
 package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper;
 
 import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
+import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -45,4 +49,26 @@ public interface ContentScraper {
      * @return Mapper Type 영문 2자 (예: "km", "da")
      */
     String getSupportedMapperType();
+
+
+    /**
+     * URL에 연결하여 Document 객체 반환 (기본 구현)
+     *
+     * @param url 연결할 URL
+     * @return 파싱된 JSoup Document
+     * @throws ArticleCollectorException 연결 오류 발생 시 FEED_PARSING_ERROR 예외 발생
+     */
+    default Document connectToUrl(String url) {
+        try {
+            return Jsoup.connect(url)
+                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+                    .timeout(5000)
+                    .ignoreContentType(true)
+                    .maxBodySize(1024 * 1024)
+                    .followRedirects(true)
+                    .get();
+        } catch (IOException e) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_PARSING_ERROR, e);
+        }
+    }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/ContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/ContentScraper.java
@@ -1,5 +1,9 @@
 package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper;
 
+import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
+
+import java.util.List;
+
 /**
  * 뉴스 본문 스크랩 interface
  * 스크래핑 로직이 신문사 마다 다름
@@ -10,17 +14,35 @@ package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.col
 public interface ContentScraper {
 
     /**
-     * 뉴스 URL에서 본문 내용을 스크래핑
+     * 뉴스 URL에서 본문 내용을 문단 단위로 스크래핑
+     *
+     * @param url 뉴스 URL
+     * @return 문단 단위로 나눈 본문 리스트
+     * @throws ArticleCollectorException 스크래핑 중 오류 발생 시
+     */
+    List<String> scrapeParagraphs(String url) throws ArticleCollectorException;
+
+    /**
+     * 뉴스 URL에서 본문 내용을 텍스트로 스크래핑
      *
      * @param url 뉴스 URL
      * @return 스크래핑된 본문
+     * @throws ArticleCollectorException 스크래핑 중 오류 발생 시
      */
-    String scrapeContent(String url);
+    String scrapeContent(String url) throws ArticleCollectorException;
+
+    /**
+     * 뉴스 URL에서 이미지 URL을 스크래핑
+     *
+     * @param url 뉴스 URL
+     * @return 스크래핑된 이미지 URL
+     */
+    String scrapeImageUrl(String url);
 
     /**
      * 스크래퍼가 지원하는 Mapper type 반환
      *
-     * @return 지원하는 Mapper Type 영문 2자 (예: "km", "da")
+     * @return Mapper Type 영문 2자 (예: "km", "da")
      */
     String getSupportedMapperType();
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/factory/ScraperFactory.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/factory/ScraperFactory.java
@@ -1,0 +1,47 @@
+// ScraperFactory.java - 팩토리 클래스
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.factory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.ContentScraper;
+
+/**
+ * 뉴스 스크래퍼 사용하는 factory Class
+ *
+ * @author 양병학
+ * @since 2025-05-13 최초 작성
+ */
+@Component
+public class ScraperFactory {
+
+    private final Map<String, ContentScraper> scrapers = new HashMap<>();
+
+    /**
+     * ContentScraper 구현체 등록
+     *
+     * @param availableScrapers ContentScraper 목록
+     */
+    @Autowired
+    public ScraperFactory(List<ContentScraper> availableScrapers) {
+        for (ContentScraper scraper : availableScrapers) {
+            String mapperType = scraper.getSupportedMapperType();
+            scrapers.put(mapperType, scraper);
+        }
+    }
+
+    /**
+     * Mapper Type에 맞는 스크래퍼 반환
+     *
+     * @param mapperType 매퍼 타입 (예: "km", "da")
+     * @return 해당 타입의 스크래퍼 or null일시 Optional로 빈 값 반환
+     */
+    public Optional<ContentScraper> getScraper(String mapperType) {
+        return Optional.ofNullable(scrapers.get(mapperType));
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/factory/ScraperFactory.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/factory/ScraperFactory.java
@@ -1,4 +1,3 @@
-// ScraperFactory.java - 팩토리 클래스
 package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.factory;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/DongaContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/DongaContentScraper.java
@@ -95,7 +95,7 @@ public class DongaContentScraper implements ContentScraper {
     @Override
     public String scrapeContent(String url) {
         List<String> paragraphs = scrapeParagraphs(url);
-        return paragraphs.stream().collect(Collectors.joining("\n\n"));
+        return String.join("\n\n", paragraphs);
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/DongaContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/DongaContentScraper.java
@@ -73,7 +73,6 @@ public class DongaContentScraper implements ContentScraper {
             }
         }
 
-        // 따옴표가 없거나 문단이 추출되지 않은 경우 전체 텍스트를 하나의 문단으로 처리
         if (paragraphs.isEmpty() && !text.trim().isEmpty()) {
             paragraphs.add(text.trim());
         }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/DongaContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/DongaContentScraper.java
@@ -1,0 +1,126 @@
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.implement;
+
+import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
+import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.ContentScraper;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.util.HtmlScraperUtils;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 동아일보 기사 본문 스크래퍼 구현체
+ *
+ * @author 양병학
+ * @since 2025-05-13 최초 작성
+ */
+@Component
+public class DongaContentScraper implements ContentScraper {
+
+    /**
+     * 동아일보 기사 URL에서 본문 내용, 문단 단위로 스크래핑
+     *
+     * @param url 기사 URL
+     * @return 문단 단위로 문단 텍스트
+     */
+    @Override
+    public List<String> scrapeParagraphs(String url) {
+        try {
+            Document document = Jsoup.connect(url).get();
+            return extractDongaContent(document);
+        } catch (IOException e) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_PARSING_ERROR, e);
+        }
+    }
+
+    /**
+     * 동아일보 본문 추출 (section.news_view에서 h2, figure 제외)
+     *
+     * @param document JSoup Document
+     * @return 문단 리스트
+     */
+    private List<String> extractDongaContent(Document document) {
+        Element newsView = HtmlScraperUtils.findElement(document, "section.news_view");
+        if (null == newsView) {
+            return new ArrayList<>();
+        }
+
+        Element processedView = HtmlScraperUtils.removeTags(newsView, "h2", "figure");
+
+        String fullText = processedView.text();
+        List<String> paragraphs = extractParagraphsByQuotes(fullText);
+
+        return paragraphs;
+    }
+
+    /**
+     * 큰따옴표 기준으로 문단 추출
+     *
+     * @param text 전체 텍스트
+     * @return 문단 리스트
+     */
+    private List<String> extractParagraphsByQuotes(String text) {
+        List<String> paragraphs = new ArrayList<>();
+
+        String[] parts = text.split("\"");
+
+        for (int i = 1; i < parts.length; i += 2) {
+            String paragraph = parts[i].trim();
+            if (!paragraph.isEmpty()) {
+                paragraphs.add(paragraph);
+            }
+        }
+
+        // 따옴표가 없거나 문단이 추출되지 않은 경우 전체 텍스트를 하나의 문단으로 처리
+        if (paragraphs.isEmpty() && !text.trim().isEmpty()) {
+            paragraphs.add(text.trim());
+        }
+
+        return paragraphs;
+    }
+
+    /**
+     * 동아일보 기사 URL에서 본문 내용을 텍스트로 스크래핑
+     *
+     * @param url 기사 URL
+     * @return 스크래핑된 본문
+     */
+    @Override
+    public String scrapeContent(String url) {
+        List<String> paragraphs = scrapeParagraphs(url);
+        return paragraphs.stream().collect(Collectors.joining("\n\n"));
+    }
+
+    /**
+     * 동아일보 기사 URL에서 이미지 URL을 스크래핑
+     *
+     * @param url 기사 URL
+     * @return 스크래핑된 이미지 URL
+     */
+    @Override
+    public String scrapeImageUrl(String url) {
+        try {
+            Document document = Jsoup.connect(url).get();
+            return HtmlScraperUtils.extractImageUrl(document, "section.news_view figure img");
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    /**
+     * 지원하는 매퍼 타입 반환
+     *
+     * @return 동아일보 매퍼 타입 (da)
+     */
+    @Override
+    public String getSupportedMapperType() {
+        return "da";
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/KhanContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/KhanContentScraper.java
@@ -5,25 +5,27 @@ import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.Art
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.ContentScraper;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.util.HtmlScraperUtils;
 
-import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 경향신문 기사 본문 스크래퍼 구현체
  *
  * @author 양병학
  * @since 2025-05-13 최초 작성
+ * @modified 2025-05-17 디버깅 및 로깅 추가
  */
 @Component
 public class KhanContentScraper implements ContentScraper {
+
+    private static final Logger logger = LoggerFactory.getLogger(KhanContentScraper.class);
 
     /**
      * 경향신문 기사 URL에서 본문 내용을 문단 단위로 스크래핑
@@ -34,10 +36,24 @@ public class KhanContentScraper implements ContentScraper {
     @Override
     public List<String> scrapeParagraphs(String url) {
         try {
-            Document document = Jsoup.connect(url).get();
-            return extractKhanContent(document);
-        } catch (IOException e) {
-            throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_PARSING_ERROR, e);
+            logger.info("경향신문 기사 스크래핑 시작: {}", url);
+            Document document = connectToUrl(url);
+            logger.info("경향신문 URL 연결 성공: {}", url);
+
+            // 디버깅: HTML 구조 출력
+            logger.debug("연결된 문서 제목: {}", document.title());
+
+            List<String> paragraphs = extractKhanContent(document);
+            logger.info("경향신문 본문 스크래핑 결과: 문단 수 = {}", paragraphs.size());
+
+            if (paragraphs.isEmpty()) {
+                logger.warn("경향신문 본문 스크래핑 실패: 문단을 찾을 수 없음");
+            }
+
+            return paragraphs;
+        } catch (Exception e) {
+            logger.error("경향신문 기사 스크래핑 오류: {}", e.getMessage(), e);
+            throw e;
         }
     }
 
@@ -48,8 +64,36 @@ public class KhanContentScraper implements ContentScraper {
      * @return 문단 리스트
      */
     private List<String> extractKhanContent(Document document) {
+        // 다양한 컨테이너 선택자 시도
         Element artBody = HtmlScraperUtils.findElement(document, "article.art_body");
-        return null == artBody ? new ArrayList<>() : extractKhanContentFromElement(artBody);
+
+        if (artBody == null) {
+            logger.debug("article.art_body 선택자로 본문을 찾을 수 없음, 다른 선택자 시도");
+            // 다른 가능한 선택자 시도
+            artBody = HtmlScraperUtils.findElement(document, "div.art_body");
+        }
+
+        if (artBody == null) {
+            logger.debug("div.art_body 선택자로 본문을 찾을 수 없음, 다른 선택자 시도");
+            artBody = HtmlScraperUtils.findElement(document, "div.article_view");
+        }
+
+        if (artBody == null) {
+            logger.debug("div.article_view 선택자로 본문을 찾을 수 없음, 다른 선택자 시도");
+            artBody = HtmlScraperUtils.findElement(document, "div.article-body");
+        }
+
+        if (artBody == null) {
+            logger.warn("모든 선택자로 본문을 찾을 수 없음");
+
+            // 전체 HTML 구조 로깅
+            logger.debug("HTML 구조: {}", document.toString().substring(0, Math.min(1000, document.toString().length())));
+
+            return new ArrayList<>();
+        }
+
+        logger.info("본문 컨테이너 발견: {}", artBody.tagName() + (artBody.hasAttr("class") ? "." + artBody.attr("class") : ""));
+        return extractKhanContentFromElement(artBody);
     }
 
     /**
@@ -59,14 +103,50 @@ public class KhanContentScraper implements ContentScraper {
      * @return 문단 리스트
      */
     private List<String> extractKhanContentFromElement(Element artBody) {
-        Element processedBody = HtmlScraperUtils.removeTags(artBody, "h3", "div.art_photo");
+        // h3, div.art_photo, img 태그 제거
+        Element processedBody = HtmlScraperUtils.removeTags(artBody, "h3", "div.art_photo", "img");
 
+        // 스타일 관련 속성 제거
+        processedBody.select("*").forEach(el -> {
+            el.removeAttr("align");
+            el.removeAttr("vspace");
+            el.removeAttr("hspace");
+            el.removeAttr("style");
+            el.removeAttr("width");
+            el.removeAttr("height");
+        });
+
+        // p 태그 시도
         Elements paragraphs = processedBody.select("p");
 
-        return paragraphs.stream()
+        // p 태그가 없으면 다른 태그 시도
+        if (paragraphs.isEmpty()) {
+            logger.debug("p 태그가 없음, div 태그로 시도");
+            paragraphs = processedBody.select("div.article_paragraph");
+        }
+
+        if (paragraphs.isEmpty()) {
+            logger.debug("div.article_paragraph 태그가 없음, span 태그로 시도");
+            paragraphs = processedBody.select("span.article_text");
+        }
+
+        if (paragraphs.isEmpty()) {
+            logger.warn("모든 문단 선택자가 실패함, 본문 전체 텍스트를 하나의 문단으로 반환");
+            List<String> fallback = new ArrayList<>();
+            String fullText = processedBody.text().trim();
+            if (!fullText.isEmpty()) {
+                fallback.add(fullText);
+            }
+            return fallback;
+        }
+
+        List<String> result = paragraphs.stream()
                 .map(Element::text)
                 .filter(text -> !text.trim().isEmpty())
                 .toList();
+
+        logger.debug("추출된 문단 수: {}", result.size());
+        return result;
     }
 
     /**
@@ -78,7 +158,7 @@ public class KhanContentScraper implements ContentScraper {
     @Override
     public String scrapeContent(String url) {
         List<String> paragraphs = scrapeParagraphs(url);
-        return paragraphs.stream().collect(Collectors.joining("\n\n"));
+        return String.join("\n\n", paragraphs);
     }
 
     /**
@@ -90,11 +170,90 @@ public class KhanContentScraper implements ContentScraper {
     @Override
     public String scrapeImageUrl(String url) {
         try {
-            Document document = Jsoup.connect(url).get();
-            return HtmlScraperUtils.extractImageUrl(document, "article.art_body div.art_photo img");
-        } catch (IOException e) {
-            return "";
+            logger.info("경향신문 이미지 URL 스크래핑 시작: {}", url);
+            Document document = connectToUrl(url);
+            logger.info("경향신문 URL 연결 성공 (이미지 스크래핑): {}", url);
+
+            String imageUrl = extractImageUrlFromDocument(document);
+
+            if (imageUrl.isEmpty()) {
+                logger.warn("경향신문 이미지 URL 스크래핑 실패: 이미지를 찾을 수 없음");
+            } else {
+                logger.info("경향신문 이미지 URL 스크래핑 성공: {}", imageUrl);
+            }
+
+            return imageUrl;
+        } catch (Exception e) {
+            logger.error("경향신문 이미지 URL 스크래핑 오류: {}", e.getMessage(), e);
+            throw e;
         }
+    }
+
+    /**
+     * Document에서 이미지 URL 추출
+     *
+     * @param document 파싱된 JSoup Document
+     * @return 추출된 이미지 URL
+     */
+    private String extractImageUrlFromDocument(Document document) {
+        // 모든 시도를 로깅
+
+        // 1. 메타 태그 시도 (og:image) - 가장 신뢰할 수 있는 소스
+        Element metaImg = document.selectFirst("meta[property=og:image]");
+        if (metaImg != null && !metaImg.attr("content").isEmpty()) {
+            logger.debug("메타 태그에서 이미지 URL 찾음 (og:image)");
+            return metaImg.attr("content");
+        }
+
+        // 2. 대표 이미지 (picture > img) 시도
+        Element mainImg = document.selectFirst("picture img");
+        if (mainImg != null && !mainImg.attr("src").isEmpty()) {
+            logger.debug("picture > img에서 이미지 URL 찾음");
+            return mainImg.attr("abs:src");
+        }
+
+        // 3. picture > source 시도
+        Element source = document.selectFirst("picture source");
+        if (source != null && !source.attr("srcset").isEmpty()) {
+            logger.debug("picture > source에서 이미지 URL 찾음");
+            String srcset = source.attr("srcset");
+            String[] sources = srcset.split(",");
+            if (sources.length > 0) {
+                String firstSource = sources[0].trim().split("\\s+")[0];
+                return source.absUrl("srcset").isEmpty() ? firstSource : source.absUrl("srcset");
+            }
+        }
+
+        // 4. 본문 내 첫 번째 이미지 시도
+        Element contentImg = document.selectFirst("article.art_body img");
+        if (contentImg != null && !contentImg.attr("src").isEmpty()) {
+            logger.debug("article.art_body img에서 이미지 URL 찾음");
+            return contentImg.attr("abs:src");
+        }
+
+        // 5. div.art_photo 내 이미지 시도
+        Element imgContainer = document.selectFirst("div.art_photo img");
+        if (imgContainer != null && !imgContainer.attr("src").isEmpty()) {
+            logger.debug("div.art_photo img에서 이미지 URL 찾음");
+            return imgContainer.attr("abs:src");
+        }
+
+        // 6. figure 내 이미지 시도
+        Element figureImg = document.selectFirst("figure img");
+        if (figureImg != null && !figureImg.attr("src").isEmpty()) {
+            logger.debug("figure img에서 이미지 URL 찾음");
+            return figureImg.attr("abs:src");
+        }
+
+        // 7. 첫 번째 이미지 태그 시도 (최후의 수단)
+        Element anyImg = document.selectFirst("img");
+        if (anyImg != null && !anyImg.attr("src").isEmpty()) {
+            logger.debug("첫 번째 img 태그에서 이미지 URL 찾음");
+            return anyImg.attr("abs:src");
+        }
+
+        logger.warn("어떤 방법으로도 이미지 URL을 찾을 수 없음");
+        return "";
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/KhanContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/KhanContentScraper.java
@@ -59,16 +59,14 @@ public class KhanContentScraper implements ContentScraper {
      * @return 문단 리스트
      */
     private List<String> extractKhanContentFromElement(Element artBody) {
-        // h3, div.art_photo 태그 제거
         Element processedBody = HtmlScraperUtils.removeTags(artBody, "h3", "div.art_photo");
 
-        // 경향신문은 p 태그로 문단 구분
         Elements paragraphs = processedBody.select("p");
 
         return paragraphs.stream()
                 .map(Element::text)
                 .filter(text -> !text.trim().isEmpty())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/KhanContentScraper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/implement/KhanContentScraper.java
@@ -1,0 +1,111 @@
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.implement;
+
+import com.likelion.backendplus4.talkpick.batch.news.article.exception.ArticleCollectorException;
+import com.likelion.backendplus4.talkpick.batch.news.article.exception.error.ArticleCollectorErrorCode;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.ContentScraper;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.util.HtmlScraperUtils;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 경향신문 기사 본문 스크래퍼 구현체
+ *
+ * @author 양병학
+ * @since 2025-05-13 최초 작성
+ */
+@Component
+public class KhanContentScraper implements ContentScraper {
+
+    /**
+     * 경향신문 기사 URL에서 본문 내용을 문단 단위로 스크래핑
+     *
+     * @param url 기사 URL
+     * @return 문단 단위로 나눈 본문 리스트
+     */
+    @Override
+    public List<String> scrapeParagraphs(String url) {
+        try {
+            Document document = Jsoup.connect(url).get();
+            return extractKhanContent(document);
+        } catch (IOException e) {
+            throw new ArticleCollectorException(ArticleCollectorErrorCode.FEED_PARSING_ERROR, e);
+        }
+    }
+
+    /**
+     * 경향신문 본문 추출 (article.art_body에서 h3, div.art_photo 제외)
+     *
+     * @param document JSoup Document
+     * @return 문단 리스트
+     */
+    private List<String> extractKhanContent(Document document) {
+        Element artBody = HtmlScraperUtils.findElement(document, "article.art_body");
+        return null == artBody ? new ArrayList<>() : extractKhanContentFromElement(artBody);
+    }
+
+    /**
+     * 경향신문 본문 요소에서 콘텐츠 추출
+     *
+     * @param artBody 기사 본문 요소
+     * @return 문단 리스트
+     */
+    private List<String> extractKhanContentFromElement(Element artBody) {
+        // h3, div.art_photo 태그 제거
+        Element processedBody = HtmlScraperUtils.removeTags(artBody, "h3", "div.art_photo");
+
+        // 경향신문은 p 태그로 문단 구분
+        Elements paragraphs = processedBody.select("p");
+
+        return paragraphs.stream()
+                .map(Element::text)
+                .filter(text -> !text.trim().isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 경향신문 기사 URL에서 본문 내용을 텍스트로 스크래핑
+     *
+     * @param url 기사 URL
+     * @return 스크래핑된 본문
+     */
+    @Override
+    public String scrapeContent(String url) {
+        List<String> paragraphs = scrapeParagraphs(url);
+        return paragraphs.stream().collect(Collectors.joining("\n\n"));
+    }
+
+    /**
+     * 경향신문 기사 URL에서 이미지 URL을 스크래핑
+     *
+     * @param url 기사 URL
+     * @return 스크래핑된 이미지 URL
+     */
+    @Override
+    public String scrapeImageUrl(String url) {
+        try {
+            Document document = Jsoup.connect(url).get();
+            return HtmlScraperUtils.extractImageUrl(document, "article.art_body div.art_photo img");
+        } catch (IOException e) {
+            return "";
+        }
+    }
+
+    /**
+     * 지원하는 매퍼 타입 반환
+     *
+     * @return 경향신문 매퍼 타입 (kh)
+     */
+    @Override
+    public String getSupportedMapperType() {
+        return "kh";
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/util/HtmlScraperUtils.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/support/scraper/util/HtmlScraperUtils.java
@@ -1,0 +1,203 @@
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.collector.support.scraper.util;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * HTML 태그별 스크래핑 유틸리티 클래스
+ *
+ * @author 양병학
+ * @since 2025-05-13 최초 작성
+ */
+public class HtmlScraperUtils {
+
+    /**
+     * 지정된 CSS 선택자에 해당하는 요소 찾기
+     *
+     * @param document JSoup Document
+     * @param selector CSS 선택자
+     * @return 찾은 요소, 없으면 null
+     */
+    public static Element findElement(Document document, String selector) {
+        return null != document ? document.selectFirst(selector) : null;
+    }
+
+    /**
+     * 지정된 CSS 선택자에 해당하는 모든 요소 찾기
+     *
+     * @param document JSoup Document
+     * @param selector CSS 선택자
+     * @return 찾은 요소들의 목록
+     */
+    public static Elements findElements(Document document, String selector) {
+        return null != document ? document.select(selector) : new Elements();
+    }
+
+    /**
+     * 특정 요소에서 지정된 태그들 제거
+     *
+     * @param element 처리할 요소
+     * @param tagsToRemove 제거할 태그 목록 (예: "h2", "figure")
+     * @return 태그가 제거된 요소 (원본은 변경되지 않음)
+     */
+    public static Element removeTags(Element element, String... tagsToRemove) {
+        return null == element ? null : doRemoveTags(element, tagsToRemove);
+    }
+
+    private static Element doRemoveTags(Element element, String... tagsToRemove) {
+        Element clone = element.clone();
+
+        for (String tag : tagsToRemove) {
+            clone.select(tag).remove();
+        }
+
+        return clone;
+    }
+
+    /**
+     * 요소에서 텍스트 추출 (HTML 태그 제거)
+     *
+     * @param element 추출할 요소
+     * @return 추출된 텍스트, 요소가 null이면 빈 문자열
+     */
+    public static String extractText(Element element) {
+        return null != element ? element.text() : "";
+    }
+
+    /**
+     * 여러 요소에서 텍스트 추출하여 결합
+     *
+     * @param elements 처리할 요소들
+     * @param separator 텍스트 사이에 넣을 구분자 (예: "\n\n")
+     * @return 결합된 텍스트
+     */
+    public static String extractCombinedText(Elements elements, String separator) {
+        return null != elements && !elements.isEmpty()
+                ? String.join(separator, elements.stream().map(Element::text).collect(Collectors.toList()))
+                : "";
+    }
+
+    /**
+     * p 태그의 내용을 개별 문단으로 추출
+     *
+     * @param container p 태그를 포함하는 요소
+     * @return 각 p 태그의 내용을 담은 문단 리스트
+     */
+    public static List<String> extractParagraphs(Element container) {
+        return null == container ? new ArrayList<>() : doParagraphExtraction(container);
+    }
+
+    /**
+     * p 태그 추출 실제 로직
+     *
+     * @param container p 태그를 포함하는 요소
+     * @return 추출된 문단 리스트
+     */
+    private static List<String> doParagraphExtraction(Element container) {
+        Elements paragraphs = container.select("p");
+        return paragraphs.stream()
+                .map(Element::text)
+                .filter(text -> !text.trim().isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * p 태그의 텍스트를 결합하여 추출
+     *
+     * @param container p 태그를 포함하는 요소
+     * @param separator 텍스트 사이에 넣을 구분자 (기본값: "\n\n")
+     * @return 결합된.텍스트
+     */
+    public static String extractParagraphText(Element container, String separator) {
+        return null != container
+                ? extractCombinedText(container.select("p"), separator)
+                : "";
+    }
+
+    /**
+     * p 태그의 텍스트를 줄바꿈으로 결합하여 추출 (기본 구분자: "\n\n")
+     *
+     * @param container p 태그를 포함하는 요소
+     * @return 결합된 텍스트
+     */
+    public static String extractParagraphText(Element container) {
+        return extractParagraphText(container, "\n\n");
+    }
+
+    /**
+     * 이미지 URL 추출
+     *
+     * @param document JSoup Document
+     * @param imgSelector 이미지 선택자
+     * @return 이미지 URL, 없으면 빈 문자열
+     */
+    public static String extractImageUrl(Document document, String imgSelector) {
+        Element img = findElement(document, imgSelector);
+        return null != img ? img.absUrl("src") : "";
+    }
+
+    /**
+     * HTML 요소 내용 처리 - 공통 메서드
+     *
+     * @param document JSoup Document
+     * @param selector 요소 선택자
+     * @param excludeTags 제외할 태그 목록
+     * @return 처리된 텍스트
+     */
+    public static String processElement(Document document, String selector, String... excludeTags) {
+        Element element = findElement(document, selector);
+        return null != element
+                ? extractText(removeTags(element, excludeTags))
+                : "";
+    }
+
+    /**
+     * section 태그 내용 처리
+     *
+     * @param document JSoup Document
+     * @param sectionSelector section 태그 선택자
+     * @param excludeTags 제외할 태그 목록
+     * @return 처리된 텍스트
+     */
+    public static String processSection(Document document, String sectionSelector, String... excludeTags) {
+        Element section = findElement(document, sectionSelector);
+        return null != section
+                ? extractText(removeTags(section, excludeTags))
+                : "";
+    }
+
+    /**
+     * article 태그 내용 처리
+     *
+     * @param document JSoup Document
+     * @param articleSelector article 태그 선택자
+     * @param excludeTags 제외할 태그 목록
+     * @return 처리된 텍스트
+     */
+    public static String processArticle(Document document, String articleSelector, String... excludeTags) {
+        Element article = findElement(document, articleSelector);
+        return null != article
+                ? extractText(removeTags(article, excludeTags))
+                : "";
+    }
+
+    /**
+     * div 태그 내용 처리
+     *
+     * @param document JSoup Document
+     * @param divSelector div 태그 선택자
+     * @param excludeTags 제외할 태그 목록
+     * @return 처리된 텍스트
+     */
+    public static String processDiv(Document document, String divSelector, String... excludeTags) {
+        Element div = findElement(document, divSelector);
+        return null != div
+                ? extractText(removeTags(div, excludeTags))
+                : "";
+    }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/entity/ArticleEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/entity/ArticleEntity.java
@@ -51,8 +51,13 @@ public class ArticleEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "is_summary")
-    private boolean isSummary;
+    @Setter
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    @Setter
+    @Column(name = "image_url")
+    private String imageUrl;
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -64,6 +69,10 @@ public class ArticleEntity {
 
     public String getDescription(){
         return description != null ? description : "";
+    }
+
+    public String getSummary() {
+        return summary != null ? summary : "";
     }
 
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/entity/ArticleEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/entity/ArticleEntity.java
@@ -74,5 +74,4 @@ public class ArticleEntity {
     public String getSummary() {
         return summary != null ? summary : "";
     }
-
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/repository/RssNewsRepository.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/repository/RssNewsRepository.java
@@ -3,10 +3,23 @@ package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface RssNewsRepository extends JpaRepository<ArticleEntity, Long> {
 
     boolean existsByLink(String link);
+
+    /**
+     * 특정 언론사의 가장 최신 기사 발행일 조회
+     *
+     * @param guidPrefix 언론사 GUID 접두어 (예: "KM", "DA", "KH")
+     * @return 가장 최신 발행일
+     */
+    @Query("SELECT MAX(a.pubDate) FROM ArticleEntity a WHERE a.guid LIKE CONCAT(:guidPrefix, '%')")
+    LocalDateTime findLatestPubDateByGuidPrefix(@Param("guidPrefix") String guidPrefix);
 }


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
### **✨ RSS 피드 데이터 수집 구조 변경 및 스크래핑 기능 개발**

### 1. RSS 피드 데이터 수집 구조 변경
![image](https://github.com/user-attachments/assets/4673877a-65ea-49ae-8e07-a476a39cbd3c)
    - 기존 description의 요약정보 여부를 알려주번 boolean IsSummary 삭제
    - 추후 임베딩 데이터가 들어갈 String Summary 추가
    - 이미지 url이 들어갈 img_url추가

## !! 추후 PR후 서버적용시 DB 구조 변경 필요
수정 후 구조  
![image](https://github.com/user-attachments/assets/b6430f95-779b-4aed-af7d-171f76afe731)

### 2.스크래핑 기능 개발
news.article.infrastructure.collector.support.scraper 에 위치
![image](https://github.com/user-attachments/assets/94c99447-f612-4f4b-a781-21e17d178fdf)
    현재 구현한 3가지 Mapper중
    본문정보와 이미지정보를 모두 포함하고 있는 국민일보를 제외하고
    두가지 언론사(동아일보, 경향신문) 스크래핑
    
  **동아일보** : rss데이터에 본문 미포함, 이미지 포함 -> 따라서 본문 매핑만 진행
  **경항신문** : rss데이터에 본문,이미지 미포함          -> 본문, 이미지 매핑 진행
  (뉴스사 별 해당 정리 정보: [링크](https://discord.com/channels/1348615911741063250/1371245929436287048/1371245935346188408) U19셸)


   - **스크래핑 인터페이스** 
      ContentScraper ------(implements)-----> DongaContentsScrapper(동아), KhanContentsScrapper(경향
        
   - **스크래핑 관련 공통 기능 유틸리티 클래스 (utils/HtmlScraperUtils.java)**
     

## 🔍 리뷰어에게
- **스크래핑 로직 분리:** 각 신문사별 스크래핑 로직을 별도 클래스로 분리했습니다. 
  **HtmlScraperUtils** 유틸리티 클래스에다가 공통 기능을 추출해서 모아놨는데, 
  유틸리티 기능이 적절히 구현됬는데 확인해주시면 감사하겠습니다.
- **DB 구조 변경:** 이미지 URL과 요약 정보를 저장하기 위한 필드가 추가/변경되었습니다. 
                          이 변경에 따른 마이그레이션 계획이 필요할 것 같습니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
closed #56