### PR TITLE
✨  Feature/#58-뉴스-데이터-Elasticsearch-저장

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/common/configuration/elasticsearch/ElasticsearchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/common/configuration/elasticsearch/ElasticsearchConfig.java
@@ -1,0 +1,7 @@
+package com.likelion.backendplus4.talkpick.batch.common.configuration.elasticsearch;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/port/in/NewsIndexUseCase.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/port/in/NewsIndexUseCase.java
@@ -1,0 +1,5 @@
+package com.likelion.backendplus4.talkpick.batch.index.application.port.in;
+
+public interface NewsIndexUseCase {
+	int indexAllNewsInfo();
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/port/out/NewsInfoIndexRepositoryPort.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/port/out/NewsInfoIndexRepositoryPort.java
@@ -1,0 +1,22 @@
+package com.likelion.backendplus4.talkpick.batch.index.application.port.out;
+
+import java.util.List;
+
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+
+/**
+ * 뉴스 정보를 색인 저장소에 저장하는 포트 인터페이스
+ *
+ * @since 2025-05-15
+ */
+public interface NewsInfoIndexRepositoryPort {
+	/**
+	 * 뉴스 정보 리스트를 색인 저장소에 저장한다.
+	 *
+	 * @param newsList 저장할 뉴스 정보 리스트
+	 * @return 저장된 뉴스 정보 건수
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	int saveAll(List<NewsInfo> newsList);
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/port/out/NewsInfoProviderPort.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/port/out/NewsInfoProviderPort.java
@@ -4,6 +4,18 @@ import java.util.List;
 
 import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
 
+/**
+ * 외부 또는 내부에서 뉴스 정보를 조회하는 포트 인터페이스
+ *
+ * @since 2025-05-15
+ */
 public interface NewsInfoProviderPort {
+	/**
+	 * 저장된 모든 뉴스 정보를 조회한다.
+	 *
+	 * @return 조회된 뉴스 정보 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
 	List<NewsInfo> fetchAll();
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/service/NewsIndexService.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/application/service/NewsIndexService.java
@@ -1,0 +1,43 @@
+package com.likelion.backendplus4.talkpick.batch.index.application.service;
+
+import java.util.List;
+
+import org.elasticsearch.index.IndexService;
+import org.springframework.stereotype.Service;
+
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.EntryExitLog;
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.TimeTracker;
+import com.likelion.backendplus4.talkpick.batch.index.application.port.in.NewsIndexUseCase;
+import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoIndexRepositoryPort;
+import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoProviderPort;
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 뉴스 정보를 조회하고 색인 저장소에 전달하는 비즈니스 로직 서비스
+ *
+ * @since 2025-05-15
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NewsIndexService implements NewsIndexUseCase {
+	private final NewsInfoProviderPort newsInfoProviderPort;
+	private final NewsInfoIndexRepositoryPort newsInfoIndexRepositoryPort;
+
+	/**
+	 * 모든 뉴스 정보를 가져와 색인 저장소에 저장하고 저장된 건수를 반환한다.
+	 *
+	 * @return 색인된 뉴스 정보 건수
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@EntryExitLog()
+	@Override
+	public int indexAllNewsInfo() {
+		List<NewsInfo> newsInfoList = newsInfoProviderPort.fetchAll();
+		return newsInfoIndexRepositoryPort.saveAll(newsInfoList);
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/domain/model/NewsInfo.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/domain/model/NewsInfo.java
@@ -5,6 +5,11 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 뉴스 정보를 표현하는 도메인 모델
+ *
+ * @since 2025-05-15
+ */
 @RequiredArgsConstructor
 @Getter
 public class NewsInfo{

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/infrastructure/adapter/ElasticsearchNewsInfoAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/infrastructure/adapter/ElasticsearchNewsInfoAdapter.java
@@ -1,0 +1,157 @@
+package com.likelion.backendplus4.talkpick.batch.index.infrastructure.adapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.IndexedObjectInformation;
+import org.springframework.data.elasticsearch.core.RefreshPolicy;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.BulkOptions;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoIndexRepositoryPort;
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+import com.likelion.backendplus4.talkpick.batch.index.infrastructure.adapter.document.NewsInfoDocument;
+import com.likelion.backendplus4.talkpick.batch.index.infrastructure.adapter.mapper.NewsInfoDocumentMapper;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Spring Data Elasticsearch를 이용해 뉴스 정보를 Bulk 색인하고 저장된 개수를 반환하는 어댑터
+ *
+ * @since 2025-05-15
+ */
+@Component
+public class ElasticsearchNewsInfoAdapter implements NewsInfoIndexRepositoryPort {
+
+	private final ElasticsearchOperations esOperations;
+	private final NewsInfoDocumentMapper mapper;
+	private final String indexName;
+	private IndexOperations indexOperations;
+
+	public ElasticsearchNewsInfoAdapter(ElasticsearchOperations esOperations,
+		NewsInfoDocumentMapper mapper,
+		@Value("${news.index.name}") String indexName) {
+		this.esOperations = esOperations;
+		this.mapper = mapper;
+		this.indexName = indexName;
+	}
+
+	/**
+	 * 초기화 단계에서 인덱스를 준비하고 존재하지 않으면 생성한다.
+	 *
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@PostConstruct
+	public void initIndex() {
+		this.indexOperations = esOperations.indexOps(IndexCoordinates.of(indexName));
+		ensureIndexExists(this.indexOperations);
+	}
+
+	/**
+	 * 뉴스 정보 리스트를 Bulk 색인하고 색인된 개수를 반환한다.
+	 *
+	 * @param newsList 색인할 뉴스 정보 리스트
+	 * @return 색인된 객체 정보 리스트의 크기
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@Override
+	public int saveAll(List<NewsInfo> newsList) {
+		List<IndexQuery> queries = toIndexQueries(newsList);
+		List<IndexedObjectInformation> result = bulkIndex(indexOperations, queries);
+
+		return result.size();
+	}
+
+	/**
+	 * 인덱스가 없으면 생성하고 매핑을 설정한다.
+	 *
+	 * @param ops 인덱스 운영 객체
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private void ensureIndexExists(IndexOperations ops) {
+		if (!ops.exists()) {
+			ops.create();
+			ops.putMapping(Document
+				.create()
+				.append("properties", mappingProperties()));
+		}
+	}
+
+	/**
+	 * 문서 매핑에 사용할 Elasticsearch 프로퍼티 맵을 반환한다.
+	 *
+	 * @return 매핑 프로퍼티 맵
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private Map<String, Object> mappingProperties() {
+		return Map.of(
+			NewsInfoDocument.FIELD_ID, Map.of("type", "keyword"),
+			NewsInfoDocument.FIELD_TITLE, Map.of(
+				"type",     "text",
+				"analyzer", NewsInfoDocument.ANALYZER_NORI,
+				"fields",   Map.of(
+					NewsInfoDocument.FIELD_KEYWORD, Map.of("type", "keyword")
+				)
+			),
+			NewsInfoDocument.FIELD_CONTENT, Map.of(
+				"type",     "text",
+				"analyzer", NewsInfoDocument.ANALYZER_NORI,
+				"fields",   Map.of(
+					NewsInfoDocument.FIELD_KEYWORD, Map.of("type", "keyword")
+				)
+			),
+			NewsInfoDocument.FIELD_PUBLISHED_AT, Map.of("type", "date"),
+			NewsInfoDocument.FIELD_IMAGE_URL,   Map.of("type", "keyword"),
+			NewsInfoDocument.FIELD_CATEGORY,    Map.of("type", "keyword")
+		);
+	}
+
+	/**
+	 * 도메인 객체를 Elasticsearch 색인 쿼리로 변환한다.
+	 *
+	 * @param newsList 도메인 객체 리스트
+	 * @return 색인 쿼리 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private List<IndexQuery> toIndexQueries(List<NewsInfo> newsList) {
+		return newsList.stream()
+			.map(n -> new IndexQueryBuilder()
+				.withId(n.getNewsId())
+				.withObject(mapper.toDocument(n))
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Bulk 옵션을 사용해 쿼리를 실행하고 결과 정보를 반환한다.
+	 *
+	 * @param indexOperations 인덱스 운영 객체
+	 * @param queries 색인 쿼리 리스트
+	 * @return 색인 결과 객체 정보 리스트
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	private List<IndexedObjectInformation> bulkIndex(IndexOperations indexOperations,
+		List<IndexQuery> queries) {
+
+		BulkOptions bulkOptions = BulkOptions.builder()
+			.withRefreshPolicy(RefreshPolicy.NONE)
+			.build();
+
+		return esOperations.bulkIndex(queries, bulkOptions,
+			indexOperations.getIndexCoordinates());
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/infrastructure/adapter/document/NewsInfoDocument.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/infrastructure/adapter/document/NewsInfoDocument.java
@@ -1,0 +1,33 @@
+package com.likelion.backendplus4.talkpick.batch.index.infrastructure.adapter.document;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Elasticsearch에 저장될 뉴스 정보 문서 모델 클래스
+ *
+ * @since 2025-05-15
+ */
+@Getter
+@AllArgsConstructor
+public class NewsInfoDocument {
+	private final String newsId;
+	private final String title;
+	private final String content;
+	private final LocalDateTime publishedAt;
+	private final String imageUrl;
+	private final String category;
+
+	public static final String FIELD_ID           = "newsId";
+	public static final String FIELD_TITLE        = "title";
+	public static final String FIELD_CONTENT      = "content";
+	public static final String FIELD_PUBLISHED_AT = "publishedAt";
+	public static final String FIELD_IMAGE_URL    = "imageUrl";
+	public static final String FIELD_CATEGORY     = "category";
+
+	public static final String ANALYZER_NORI      = "nori";
+	public static final String FIELD_KEYWORD      = "keyword";
+}
+

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/infrastructure/adapter/mapper/NewsInfoDocumentMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/infrastructure/adapter/mapper/NewsInfoDocumentMapper.java
@@ -1,0 +1,34 @@
+package com.likelion.backendplus4.talkpick.batch.index.infrastructure.adapter.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+import com.likelion.backendplus4.talkpick.batch.index.infrastructure.adapter.document.NewsInfoDocument;
+
+/**
+ * 도메인 모델 NewsInfo를 Elasticsearch 문서 모델로 변환하는 매퍼
+ *
+ * @since 2025-05-15
+ */
+@Component
+public class NewsInfoDocumentMapper {
+	/**
+	 * NewsInfo 도메인 객체를 NewsInfoDocument로 변환한다.
+	 *
+	 * @param news 변환할 도메인 객체
+	 * @return 변환된 문서 객체
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	public NewsInfoDocument toDocument(NewsInfo news) {
+		return new NewsInfoDocument(
+			news.getNewsId(),
+			news.getTitle(),
+			news.getContent(),
+			news.getPublishedAt(),
+			news.getImageUrl(),
+			news.getCategory()
+		);
+	}
+}
+

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/presentation/controller/NewsIndexController.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/presentation/controller/NewsIndexController.java
@@ -1,0 +1,41 @@
+package com.likelion.backendplus4.talkpick.batch.index.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.EntryExitLog;
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.TimeTracker;
+import com.likelion.backendplus4.talkpick.batch.common.response.ApiResponse;
+import com.likelion.backendplus4.talkpick.batch.index.application.port.in.NewsIndexUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 뉴스 데이터 일괄 색인을 위한 REST 컨트롤러
+ *
+ * @since 2025-05-15
+ */
+@RestController
+@RequestMapping("/news")
+@RequiredArgsConstructor
+public class NewsIndexController {
+
+	private final NewsIndexUseCase indexUseCase;
+
+	/**
+	 * 전체 뉴스 정보를 색인하고 처리 건수를 반환한다.
+	 *
+	 * @return ApiResponse에 래핑된 색인된 뉴스 건수
+	 * @author 정안식
+	 * @since 2025-05-15
+	 */
+	@EntryExitLog
+	@TimeTracker
+	@PostMapping("/index")
+	public ResponseEntity<ApiResponse<Integer>> indexAllNews() {
+		int count = indexUseCase.indexAllNewsInfo();
+		return ApiResponse.success(count);
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/sample/index/NewsIndexServiceTestImpl.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/sample/index/NewsIndexServiceTestImpl.java
@@ -1,0 +1,53 @@
+package com.likelion.backendplus4.talkpick.batch.sample.index;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.EntryExitLog;
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.LogMethodValues;
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.TimeTracker;
+import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoProviderPort;
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class NewsIndexServiceTestImpl implements NewsInfoProviderPort{
+
+	@EntryExitLog
+	@TimeTracker
+	@LogMethodValues
+	@Override
+	public List<NewsInfo> fetchAll() {
+		return List.of(
+			new NewsInfo(
+				"news-1",
+				"테스트 뉴스 1",
+				"첫 번째 테스트 뉴스의 내용입니다.",
+				LocalDateTime.of(2025, 5, 14, 10, 0),
+				"https://example.com/image1.jpg",
+				"테스트"
+			),
+			new NewsInfo(
+				"news-2",
+				"테스트 뉴스 2",
+				"두 번째 테스트 뉴스의 내용입니다.",
+				LocalDateTime.of(2025, 5, 13, 11, 30),
+				"https://example.com/image2.jpg",
+				"테스트"
+			),
+			new NewsInfo(
+				"news-3",
+				"테스트 뉴스 3",
+				"세 번째 테스트 뉴스의 내용입니다.",
+				LocalDateTime.of(2025, 5, 12, 14, 45),
+				"https://example.com/image3.jpg",
+				"테스트"
+			)
+		);
+	}
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ server:
       enabled: false
 
 spring:
+  elasticsearch:
+    uris: ${ELS_URI}
   ai:
     openai:
       api-key: ${OPENAI_API_KEY}
@@ -52,3 +54,7 @@ decorator:
 article-collector:
   quartz:
     cron: "0 */1 * * * ?"
+
+news:
+  index:
+    name: news_index


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결

## ✨ 변경 사항
- ELS에 저장하는 로직을 추가였습니다.

## 🔍 리뷰어에게
- indexName을 동적으로 받아오도록 하는 Port를 구성하여 런타임 중에 바라보는 ELS의 Index를 바꾸는 기능이 필요할까요?
- Hexgaonal이 잘 지켜졌는지도 확인해주세요!


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
closed #58