### PR TITLE
Feature/#59 뉴스 정보 제공 포트 어댑터 구현

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/domain/model/NewsInfo.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/domain/model/NewsInfo.java
@@ -2,11 +2,13 @@ package com.likelion.backendplus4.talkpick.batch.index.domain.model;
 
 import java.time.LocalDateTime;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
+@Builder
 public class NewsInfo{
 	private final String newsId;
 	private final String title;

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/writer/ArticleWriter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/collector/writer/ArticleWriter.java
@@ -9,7 +9,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
-import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.repository.RssNewsRepository;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.repository.NewsInfoJpaRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ArticleWriter implements ItemWriter<List<ArticleEntity>> {
 
-	private final RssNewsRepository rssNewsRepository;
+	private final NewsInfoJpaRepository newsInfoJpaRepository;
 
 	/**
 	 * 기사 리스트를 저장하며, 중복된 기사는 건너뛴다.
@@ -44,7 +44,7 @@ public class ArticleWriter implements ItemWriter<List<ArticleEntity>> {
 		AtomicInteger savedCount = new AtomicInteger();
 		chunk.getItems().stream()
 			.flatMap(List::stream)
-			.filter(item -> !rssNewsRepository.existsByLink(item.getLink()))
+			.filter(item -> !newsInfoJpaRepository.existsByLink(item.getLink()))
 			.forEach(item -> {saveItem(item, savedCount);});
 		log.info("새로 저장된 뉴스 개수: {}", savedCount.get());
 	}
@@ -59,7 +59,7 @@ public class ArticleWriter implements ItemWriter<List<ArticleEntity>> {
 	 */
 	private void saveItem(ArticleEntity item, AtomicInteger savedCount) {
 		try {
-			rssNewsRepository.save(item);
+			newsInfoJpaRepository.save(item);
 			savedCount.incrementAndGet();
 		} catch (DataIntegrityViolationException e) {
 			log.debug("중복 항목 감지: {}", item.getLink());

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
@@ -1,0 +1,37 @@
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.adapter;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoProviderPort;
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.repository.NewsInfoJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * TODO: 이벤트 기반으로 색인 안된 뉴스만 제공하도록 수정 필요
+ * 최근 100개 뉴스 정보를 반환합니다.
+ *
+ * @since 2025-05-14
+ */
+@Component
+@RequiredArgsConstructor
+public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
+	private final NewsInfoJpaRepository newsInfoJpaRepository;
+
+	@Override
+
+	public List<NewsInfo> fetchAll() {
+		Pageable pageable = PageRequest.of(0, 100)
+			.withSort(Sort.by("pubDate").descending());
+		newsInfoJpaRepository.findAll(pageable).getContent()
+			.stream()
+			.map(newsInfo -> newsInfo);
+		return
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
@@ -26,9 +26,6 @@ import lombok.RequiredArgsConstructor;
 public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 	private final NewsInfoJpaRepository newsInfoJpaRepository;
 
-	@Override
-
-
 	/**
 	 * 뉴스 정보를 최신순으로 최대 100건까지 조회하여 도메인 객체 리스트로 반환합니다.
 	 *
@@ -36,6 +33,7 @@ public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 	 * @author 함예정
 	 * @since 2025-05-14
 	 */
+	@Override
 	public List<NewsInfo> fetchAll() {
 		Pageable pageable = PageRequest.of(0, 100)
 			.withSort(Sort.by("pubDate").descending());

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
@@ -9,14 +9,16 @@ import org.springframework.stereotype.Component;
 
 import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoProviderPort;
 import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.mapper.ArticleEntityMapper;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.repository.NewsInfoJpaRepository;
 
 import lombok.RequiredArgsConstructor;
 
 /**
  * TODO: 이벤트 기반으로 색인 안된 뉴스만 제공하도록 수정 필요
- * 최근 100개 뉴스 정보를 반환합니다.
- *
+ *  NewsInfoProviderPort 인터페이스의 구현체로,
+ *  JPA 리포지토리를 통해 뉴스 정보를 조회하는 어댑터 클래스입니다.
+ *  현재는 최근 100개 뉴스를 반환합니다.
  * @since 2025-05-14
  */
 @Component
@@ -26,12 +28,22 @@ public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 
 	@Override
 
+
+	/**
+	 * 뉴스 정보를 최신순으로 최대 100건까지 조회하여 도메인 객체 리스트로 반환합니다.
+	 *
+	 * @return 뉴스 도메인 객체 리스트
+	 * @author 함예정
+	 * @since 2025-05-14
+	 */
 	public List<NewsInfo> fetchAll() {
 		Pageable pageable = PageRequest.of(0, 100)
 			.withSort(Sort.by("pubDate").descending());
-		newsInfoJpaRepository.findAll(pageable).getContent()
+
+		return newsInfoJpaRepository.findAll(pageable)
+			.getContent()
 			.stream()
-			.map(newsInfo -> newsInfo);
-		return
+			.map(ArticleEntityMapper::toDomainFromEntity)
+			.toList();
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/adapter/NewsInfoProviderAdapter.java
@@ -35,7 +35,9 @@ public class NewsInfoProviderAdapter implements NewsInfoProviderPort {
 	 */
 	@Override
 	public List<NewsInfo> fetchAll() {
-		Pageable pageable = PageRequest.of(0, 100)
+		private static final int MAX_NEWS_COUNT = 100;
+		
+		Pageable pageable = PageRequest.of(0, MAX_NEWS_COUNT)
 			.withSort(Sort.by("pubDate").descending());
 
 		return newsInfoJpaRepository.findAll(pageable)

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/mapper/ArticleEntityMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/mapper/ArticleEntityMapper.java
@@ -1,0 +1,17 @@
+package com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.mapper;
+
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
+
+public class ArticleEntityMapper {
+	public NewsInfo toDomainFromEntity(ArticleEntity articleEntity) {
+		return NewsInfo.builder()
+			.newsId(articleEntity.getGuid())
+			.title(articleEntity.getTitle())
+			.content(articleEntity.getDescription())
+			.publishedAt(articleEntity.getPubDate())
+			.imageUrl(null) // TODO: 나중에 추가 예정
+			.category(articleEntity.getCategory())
+			.build();
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/mapper/ArticleEntityMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/mapper/ArticleEntityMapper.java
@@ -4,7 +4,7 @@ import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
 import com.likelion.backendplus4.talkpick.batch.news.article.infrastructure.jpa.entity.ArticleEntity;
 
 public class ArticleEntityMapper {
-	public NewsInfo toDomainFromEntity(ArticleEntity articleEntity) {
+	public static NewsInfo toDomainFromEntity(ArticleEntity articleEntity) {
 		return NewsInfo.builder()
 			.newsId(articleEntity.getGuid())
 			.title(articleEntity.getTitle())

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/repository/NewsInfoJpaRepository.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/repository/NewsInfoJpaRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RssNewsRepository extends JpaRepository<ArticleEntity, Long> {
+public interface NewsInfoJpaRepository extends JpaRepository<ArticleEntity, Long> {
 
     boolean existsByLink(String link);
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/sample/index/providerPort/NewsInfoProviderPortSample.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/sample/index/providerPort/NewsInfoProviderPortSample.java
@@ -1,0 +1,31 @@
+package com.likelion.backendplus4.talkpick.batch.sample.index.providerPort;
+
+import static com.likelion.backendplus4.talkpick.batch.common.response.ApiResponse.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.backendplus4.talkpick.batch.common.response.ApiResponse;
+import com.likelion.backendplus4.talkpick.batch.index.application.port.out.NewsInfoProviderPort;
+import com.likelion.backendplus4.talkpick.batch.index.domain.model.NewsInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sample/news/info")
+public class NewsInfoProviderPortSample {
+	private final NewsInfoProviderPort newsInfoProviderPort;
+
+	/**
+	 * 실제 사용시에는 Response 객체로 변환 필요
+	 */
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<NewsInfo>>> fetchAll() {
+		return success(newsInfoProviderPort.fetchAll());
+	}
+}


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- RssNewsRepository 클래스 이름 변경 
   -> NewsInfoJpaRepository
- 도메인 객체 NewsInfo 빌더 패턴 추가
- NewsInfoProviderAdapter 구현: JPA 레포지토리를 활용해 최근 100개 뉴스를 반환합니다
- ArticleEntityMapper 추가


## 🔍 리뷰어에게
- 코드 컨벤션에 위배 되는 내용이 없는지 확인해주세요.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #59 