### PR TITLE
Feature/#76 색인 정보 제공 포트에 뉴스 요약 추가

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/index/domain/model/NewsInfo.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/index/domain/model/NewsInfo.java
@@ -10,15 +10,18 @@ import lombok.RequiredArgsConstructor;
  * 뉴스 정보를 표현하는 도메인 모델
  *
  * @since 2025-05-15
+ * @modified 2025-05-18
  */
 @RequiredArgsConstructor
 @Getter
 @Builder
-public class NewsInfo{
+public class NewsInfo {
 	private final String newsId;
 	private final String title;
 	private final String content;
 	private final LocalDateTime publishedAt;
 	private final String imageUrl;
 	private final String category;
-	}
+	private final String summary;
+	private final float[] summaryVector;
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/mapper/ArticleEntityMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/news/article/infrastructure/jpa/mapper/ArticleEntityMapper.java
@@ -10,8 +10,10 @@ public class ArticleEntityMapper {
 			.title(articleEntity.getTitle())
 			.content(articleEntity.getDescription())
 			.publishedAt(articleEntity.getPubDate())
-			.imageUrl(null) // TODO: 나중에 추가 예정
+			.imageUrl(articleEntity.getImageUrl())
 			.category(articleEntity.getCategory())
+			.summary(articleEntity.getSummary())
+			.summaryVector(articleEntity.getSummaryVector())
 			.build();
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/sample/index/NewsIndexServiceTestImpl.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/sample/index/NewsIndexServiceTestImpl.java
@@ -29,7 +29,9 @@ public class NewsIndexServiceTestImpl implements NewsInfoProviderPort{
 				"첫 번째 테스트 뉴스의 내용입니다.",
 				LocalDateTime.of(2025, 5, 14, 10, 0),
 				"https://example.com/image1.jpg",
-				"테스트"
+				"테스트",
+				"요약1",
+				new float[] {1.0f, 2.5f, 3.3f}
 			),
 			new NewsInfo(
 				"news-2",
@@ -37,7 +39,9 @@ public class NewsIndexServiceTestImpl implements NewsInfoProviderPort{
 				"두 번째 테스트 뉴스의 내용입니다.",
 				LocalDateTime.of(2025, 5, 13, 11, 30),
 				"https://example.com/image2.jpg",
-				"테스트"
+				"테스트",
+				"요약2",
+				new float[] {1.0f, 2.5f, 3.3f}
 			),
 			new NewsInfo(
 				"news-3",
@@ -45,7 +49,9 @@ public class NewsIndexServiceTestImpl implements NewsInfoProviderPort{
 				"세 번째 테스트 뉴스의 내용입니다.",
 				LocalDateTime.of(2025, 5, 12, 14, 45),
 				"https://example.com/image3.jpg",
-				"테스트"
+				"테스트",
+				"요약3",
+				new float[] {1.0f, 2.5f, 3.3f}
 			)
 		);
 	}


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항
- 뉴스 색인 작업을 위해 도메인 객체에 summary, summaryVector 필드를 추가했습니다.
- 이에 맞춰 mapper 클래스를 수정했습니다.
- 샘플 코드 데이터가 컴파일 오류를 일으켜 임의 값을 추가했습니다.

## 🔍 리뷰어에게
- 현재는 최근 100개를 반환하게 되어있는데, 추후 색인 되지 않은 값만 반환하도록 수정해야합니다.
- 이를 위해 이벤트 기반 패턴을 진행하자는 의견이 있었습니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #76 