### PR TITLE
✨ Feature/#87 채팅 벌크 저장 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     //P6spy
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
 
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     //RSS
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
     implementation 'com.rometools:rome:1.18.0'

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/exception/ChatBatchException.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/exception/ChatBatchException.java
@@ -1,0 +1,24 @@
+package com.likelion.backendplus4.talkpick.batch.chat.exception;
+
+import com.likelion.backendplus4.talkpick.batch.common.exception.CustomException;
+import com.likelion.backendplus4.talkpick.batch.common.exception.error.ErrorCode;
+
+public class ChatBatchException extends CustomException {
+
+	private final ErrorCode errorCode;
+
+	@Override
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+
+	public ChatBatchException(ErrorCode errorCode) {
+		super(errorCode);
+		this.errorCode = errorCode;
+	}
+
+	public ChatBatchException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode, cause);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/exception/error/ChatBatchErrorCode.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/exception/error/ChatBatchErrorCode.java
@@ -10,9 +10,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ChatBatchErrorCode implements ErrorCode {
+
+	REDIS_GROUP_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 430001, "Redis 스트림 컨슈머 그룹 생성에 실패했습니다."),
 	STREAM_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 460001, "Redis Stream 읽기 실패"),
 	BATCH_LAUNCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 460002, "Batch 실행 실패");
-
 	private final HttpStatus status;
 	private final int code;
 	private final String message;

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/exception/error/ChatBatchErrorCode.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/exception/error/ChatBatchErrorCode.java
@@ -1,0 +1,34 @@
+package com.likelion.backendplus4.talkpick.batch.chat.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.likelion.backendplus4.talkpick.batch.common.exception.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatBatchErrorCode implements ErrorCode {
+	STREAM_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 460001, "Redis Stream 읽기 실패"),
+	BATCH_LAUNCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 460002, "Batch 실행 실패");
+
+	private final HttpStatus status;
+	private final int code;
+	private final String message;
+
+	@Override
+	public HttpStatus httpStatus() {
+		return status;
+	}
+
+	@Override
+	public int codeNumber() {
+		return code;
+	}
+
+	@Override
+	public String message() {
+		return message;
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
@@ -1,0 +1,31 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch;
+
+
+import org.quartz.*;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatBatchQuartzLauncher implements Job {
+
+	private final JobLauncher jobLauncher;
+
+	@Qualifier("chatFlushJob")
+	private final org.springframework.batch.core.Job chatFlushJob;
+
+	@Override
+	public void execute(JobExecutionContext context) throws JobExecutionException {
+		try {
+			jobLauncher.run(chatFlushJob,
+				new JobParametersBuilder()
+					.addLong("ts", System.currentTimeMillis())
+					.toJobParameters());
+		} catch (Exception e) {
+			throw new JobExecutionException("batch failure", e);
+		}
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
@@ -12,6 +12,11 @@ import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchEr
 
 @Component
 @RequiredArgsConstructor
+/**
+ * Quartz 스케줄러의 실행 시점에 Spring Batch의 chatFlushJob을 호출하는 Job 구현체입니다.
+ *
+ * @since 2025-05-27
+ */
 public class ChatBatchQuartzLauncher implements org.quartz.Job {
 
 	private final JobLauncher jobLauncher;
@@ -19,15 +24,33 @@ public class ChatBatchQuartzLauncher implements org.quartz.Job {
 	@Qualifier("chatFlushJob")
 	private final Job chatFlushJob;
 
+	/**
+	 * Quartz Job 실행 시 Spring Batch chatFlushJob을 실행합니다.
+	 *
+	 * @param context Quartz JobExecutionContext
+	 * @throws ChatBatchException 배치 실행 중 오류 발생 시 예외를 던집니다.
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Override
 	public void execute(JobExecutionContext context) {
-		try {
-			jobLauncher.run(chatFlushJob,
-				new JobParametersBuilder()
-					.addLong("ts", System.currentTimeMillis())
-					.toJobParameters());
-		} catch (Exception e) {
-			throw new ChatBatchException(ChatBatchErrorCode.BATCH_LAUNCH_ERROR, e);
-		}
+	    runChatFlushJob();
+	}
+
+	/**
+	 * Spring Batch chatFlushJob을 실행하고, 실행 중 예외가 발생하면 ChatBatchException을 던집니다.
+	 *
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
+	private void runChatFlushJob() {
+	    try {
+	        jobLauncher.run(chatFlushJob,
+	            new JobParametersBuilder()
+	                .addLong("ts", System.currentTimeMillis())
+	                .toJobParameters());
+	    } catch (Exception e) {
+	        throw new ChatBatchException(ChatBatchErrorCode.BATCH_LAUNCH_ERROR, e);
+	    }
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
@@ -1,5 +1,6 @@
 package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch;
 
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -16,6 +17,7 @@ import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchEr
  * @since 2025-05-27
  */
 @Component
+@DisallowConcurrentExecution
 @RequiredArgsConstructor
 public class ChatBatchQuartzLauncher implements org.quartz.Job {
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
@@ -1,31 +1,33 @@
 package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch;
 
-
-import org.quartz.*;
+import org.quartz.JobExecutionContext;
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
 
 @Component
 @RequiredArgsConstructor
-public class ChatBatchQuartzLauncher implements Job {
+public class ChatBatchQuartzLauncher implements org.quartz.Job {
 
 	private final JobLauncher jobLauncher;
 
 	@Qualifier("chatFlushJob")
-	private final org.springframework.batch.core.Job chatFlushJob;
+	private final Job chatFlushJob;
 
 	@Override
-	public void execute(JobExecutionContext context) throws JobExecutionException {
+	public void execute(JobExecutionContext context) {
 		try {
 			jobLauncher.run(chatFlushJob,
 				new JobParametersBuilder()
 					.addLong("ts", System.currentTimeMillis())
 					.toJobParameters());
 		} catch (Exception e) {
-			throw new JobExecutionException("batch failure", e);
+			throw new ChatBatchException(ChatBatchErrorCode.BATCH_LAUNCH_ERROR, e);
 		}
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/ChatBatchQuartzLauncher.java
@@ -10,13 +10,13 @@ import lombok.RequiredArgsConstructor;
 import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
 import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
 
-@Component
-@RequiredArgsConstructor
 /**
  * Quartz 스케줄러의 실행 시점에 Spring Batch의 chatFlushJob을 호출하는 Job 구현체입니다.
  *
  * @since 2025-05-27
  */
+@Component
+@RequiredArgsConstructor
 public class ChatBatchQuartzLauncher implements org.quartz.Job {
 
 	private final JobLauncher jobLauncher;

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
@@ -34,6 +34,8 @@ public class ChatBatchConfig {
 
     private static final String STEP_NAME = "chatFlushStep";
     private static final String JOB_NAME = "chatFlushJob";
+	private static final int RETRY_COUNT = 3;
+	private static final int SKIP_COUNT = 10;
 
 	private final RedisStreamItemReader reader;
 	private final RedisAckListener redisAckListener;
@@ -58,8 +60,10 @@ public class ChatBatchConfig {
 			.writer(writer())
 			.listener(redisAckListener)
 			.faultTolerant()
-			.retryLimit(3)
+			.retryLimit(RETRY_COUNT)
 			.retry(ChatBatchException.class)
+			.skipLimit(SKIP_COUNT)
+			.skip(ChatBatchException.class)
 			.build();
 	}
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
@@ -13,10 +13,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.transaction.PlatformTransactionManager;
-
+//
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
 import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.listener.RedisAckListener;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader.RedisStreamItemReader;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity.ChatMessageEntity;
 import com.likelion.backendplus4.talkpick.batch.chat.model.ChatMessage;
@@ -25,8 +26,6 @@ import com.likelion.backendplus4.talkpick.batch.chat.support.mapper.ChatMessageM
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.batch.core.listener.ChunkListenerSupport;
-import org.springframework.batch.core.SkipListener;
 
 @Configuration
 @EnableBatchProcessing
@@ -34,18 +33,11 @@ import org.springframework.batch.core.SkipListener;
 public class ChatBatchConfig {
 
 	private final RedisStreamItemReader reader;
+	private final RedisAckListener redisAckListener;
 	private final ObjectMapper objectMapper;
 	private final EntityManagerFactory emf;
 	private final JobRepository jobRepository;
 	private final PlatformTransactionManager transactionManager;
-
-	@Bean
-	public JpaItemWriter<ChatMessageEntity> writer() {
-		JpaItemWriter<ChatMessageEntity> writer = new JpaItemWriter<>();
-		writer.setEntityManagerFactory(emf);
-		writer.setUsePersist(true);
-		return writer;
-	}
 
 	@Bean
 	public Step chatFlushStep() {
@@ -54,6 +46,7 @@ public class ChatBatchConfig {
 			.reader(reader)
 			.processor(processor())
 			.writer(writer())
+			.listener(redisAckListener)
 			.faultTolerant()
 				.retryLimit(3)
 				.retry(ChatBatchException.class)
@@ -66,6 +59,14 @@ public class ChatBatchConfig {
 			.incrementer(new RunIdIncrementer())
 			.start(chatFlushStep())
 			.build();
+	}
+
+	@Bean
+	public JpaItemWriter<ChatMessageEntity> writer() {
+		JpaItemWriter<ChatMessageEntity> writer = new JpaItemWriter<>();
+		writer.setEntityManagerFactory(emf);
+		writer.setUsePersist(true);
+		return writer;
 	}
 
 	private ItemProcessor<MapRecord<String, String, String>, ChatMessageEntity> processor() {

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
@@ -7,6 +7,7 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,8 @@ import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader.RedisStreamItemReader;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity.ChatMessageEntity;
 import com.likelion.backendplus4.talkpick.batch.chat.model.ChatMessage;
@@ -21,6 +24,9 @@ import com.likelion.backendplus4.talkpick.batch.chat.support.mapper.ChatMessageM
 
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.batch.core.listener.ChunkListenerSupport;
+import org.springframework.batch.core.SkipListener;
 
 @Configuration
 @EnableBatchProcessing
@@ -46,14 +52,11 @@ public class ChatBatchConfig {
 		return new StepBuilder("chatFlushStep", jobRepository)
 			.<MapRecord<String, String, String>, ChatMessageEntity>chunk(100, transactionManager)
 			.reader(reader)
-			.processor(record -> {
-				ChatMessage domain = objectMapper.readValue(
-					record.getValue().get("payload"),
-					ChatMessage.class
-				);
-				return ChatMessageMapper.toEntityFromDomain(domain);
-			})
+			.processor(processor())
 			.writer(writer())
+			.faultTolerant()
+				.retryLimit(3)
+				.retry(ChatBatchException.class)
 			.build();
 	}
 
@@ -63,5 +66,20 @@ public class ChatBatchConfig {
 			.incrementer(new RunIdIncrementer())
 			.start(chatFlushStep())
 			.build();
+	}
+
+	private ItemProcessor<MapRecord<String, String, String>, ChatMessageEntity> processor() {
+		return record -> {
+			try {
+				ChatMessage domain = objectMapper.readValue(
+					record.getValue().get("payload"),
+					ChatMessage.class
+				);
+				return ChatMessageMapper.toEntityFromDomain(domain);
+			} catch (Exception e) {
+				throw new ChatBatchException(
+					ChatBatchErrorCode.STREAM_READ_ERROR, e);
+			}
+		};
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
@@ -7,60 +7,84 @@ import org.springframework.batch.core.configuration.annotation.EnableBatchProces
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.transaction.PlatformTransactionManager;
-//
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
-import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.listener.RedisAckListener;
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.processor.ChatMessageItemProcessor;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader.RedisStreamItemReader;
 import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity.ChatMessageEntity;
-import com.likelion.backendplus4.talkpick.batch.chat.model.ChatMessage;
-import com.likelion.backendplus4.talkpick.batch.chat.support.mapper.ChatMessageMapper;
 
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 
-
+/**
+ * Redis 스트림으로부터 채팅 메시지를 읽어와 JPA로 영속화하는 배치 잡을 설정하는 구성 클래스입니다.
+ *
+ * @since 2025-05-27
+ */
 @Configuration
 @EnableBatchProcessing
 @RequiredArgsConstructor
 public class ChatBatchConfig {
 
+    private static final String STEP_NAME = "chatFlushStep";
+    private static final String JOB_NAME = "chatFlushJob";
+
 	private final RedisStreamItemReader reader;
 	private final RedisAckListener redisAckListener;
-	private final ObjectMapper objectMapper;
 	private final EntityManagerFactory emf;
 	private final JobRepository jobRepository;
+	private final ChatMessageItemProcessor processor;
 	private final PlatformTransactionManager transactionManager;
 
+	/**
+	 * Redis 스트림에서 읽은 메시지를 처리하여 DB에 저장하는 Step을 생성합니다.
+	 *
+	 * @return 채팅 플러시를 수행하는 Step 객체
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Bean
 	public Step chatFlushStep() {
-		return new StepBuilder("chatFlushStep", jobRepository)
+		return new StepBuilder(STEP_NAME, jobRepository)
 			.<MapRecord<String, String, String>, ChatMessageEntity>chunk(100, transactionManager)
 			.reader(reader)
-			.processor(processor())
+			.processor(processor)
 			.writer(writer())
 			.listener(redisAckListener)
 			.faultTolerant()
-				.retryLimit(3)
-				.retry(ChatBatchException.class)
+			.retryLimit(3)
+			.retry(ChatBatchException.class)
 			.build();
 	}
 
+	/**
+	 * chatFlushStep을 실행하는 배치 Job을 생성합니다.
+	 *
+	 * @return 채팅 플러시 배치 Job 객체
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Bean
 	public Job chatFlushJob() {
-		return new JobBuilder("chatFlushJob", jobRepository)
+		return new JobBuilder(JOB_NAME, jobRepository)
 			.incrementer(new RunIdIncrementer())
 			.start(chatFlushStep())
 			.build();
 	}
 
+	/**
+	 * ChatMessageEntity를 저장하기 위한 JpaItemWriter 빈을 정의합니다.
+	 *
+	 * @return JpaItemWriter<ChatMessageEntity> 객체
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Bean
 	public JpaItemWriter<ChatMessageEntity> writer() {
 		JpaItemWriter<ChatMessageEntity> writer = new JpaItemWriter<>();
@@ -69,18 +93,4 @@ public class ChatBatchConfig {
 		return writer;
 	}
 
-	private ItemProcessor<MapRecord<String, String, String>, ChatMessageEntity> processor() {
-		return record -> {
-			try {
-				ChatMessage domain = objectMapper.readValue(
-					record.getValue().get("payload"),
-					ChatMessage.class
-				);
-				return ChatMessageMapper.toEntityFromDomain(domain);
-			} catch (Exception e) {
-				throw new ChatBatchException(
-					ChatBatchErrorCode.STREAM_READ_ERROR, e);
-			}
-		};
-	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/ChatBatchConfig.java
@@ -1,0 +1,67 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.config;
+
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader.RedisStreamItemReader;
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity.ChatMessageEntity;
+import com.likelion.backendplus4.talkpick.batch.chat.model.ChatMessage;
+import com.likelion.backendplus4.talkpick.batch.chat.support.mapper.ChatMessageMapper;
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class ChatBatchConfig {
+
+	private final RedisStreamItemReader reader;
+	private final ObjectMapper objectMapper;
+	private final EntityManagerFactory emf;
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
+
+	@Bean
+	public JpaItemWriter<ChatMessageEntity> writer() {
+		JpaItemWriter<ChatMessageEntity> writer = new JpaItemWriter<>();
+		writer.setEntityManagerFactory(emf);
+		writer.setUsePersist(true);
+		return writer;
+	}
+
+	@Bean
+	public Step chatFlushStep() {
+		return new StepBuilder("chatFlushStep", jobRepository)
+			.<MapRecord<String, String, String>, ChatMessageEntity>chunk(100, transactionManager)
+			.reader(reader)
+			.processor(record -> {
+				ChatMessage domain = objectMapper.readValue(
+					record.getValue().get("payload"),
+					ChatMessage.class
+				);
+				return ChatMessageMapper.toEntityFromDomain(domain);
+			})
+			.writer(writer())
+			.build();
+	}
+
+	@Bean
+	public Job chatFlushJob() {
+		return new JobBuilder("chatFlushJob", jobRepository)
+			.incrementer(new RunIdIncrementer())
+			.start(chatFlushStep())
+			.build();
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/QuartzChatConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/QuartzChatConfig.java
@@ -28,7 +28,7 @@ public class QuartzChatConfig {
     private static final String TRIGGER_NAME = "chatFlushQuartzTrigger";
     private static final String GROUP_NAME = "chatGroup";
 
-	@Value("${chat.flush.delay}")
+	@Value("${chat.flush.interval}")
 	private Long flushDelayMillis;
 
 	/**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/QuartzChatConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/QuartzChatConfig.java
@@ -1,0 +1,47 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.config;
+
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.ChatBatchQuartzLauncher;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableBatchProcessing
+public class QuartzChatConfig {
+
+	@Value("${chat.flush.delay}")
+	private Long flushDelayMillis;
+
+
+	@Bean
+	public JobDetail chatFlushJobDetail() {
+		return JobBuilder.newJob(ChatBatchQuartzLauncher.class)
+			.withIdentity("chatFlushQuartzJob", "chatGroup")
+			.storeDurably()
+			.build();
+	}
+
+	@Bean
+	public Trigger chatFlushTrigger(JobDetail chatFlushJobDetail) {
+		return TriggerBuilder.newTrigger()
+			.forJob(chatFlushJobDetail)
+			.withIdentity("chatFlushQuartzTrigger", "chatGroup")
+			.startNow()
+			.withSchedule(SimpleScheduleBuilder
+				.simpleSchedule()
+				.withIntervalInMilliseconds(flushDelayMillis)
+				.repeatForever()
+			)
+			.build();
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/QuartzChatConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/config/QuartzChatConfig.java
@@ -14,28 +14,51 @@ import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Quartz 스케줄러를 통해 채팅 배치 플러시 작업을 주기적으로 실행하도록 설정하는 구성 클래스입니다.
+ *
+ * @since 2025-05-27
+ */
 @Configuration
 @RequiredArgsConstructor
 @EnableBatchProcessing
 public class QuartzChatConfig {
 
+    private static final String JOB_NAME = "chatFlushQuartzJob";
+    private static final String TRIGGER_NAME = "chatFlushQuartzTrigger";
+    private static final String GROUP_NAME = "chatGroup";
+
 	@Value("${chat.flush.delay}")
 	private Long flushDelayMillis;
 
-
+	/**
+	 * 채팅 플러시 배치 작업(JobDetail)을 생성하여 Quartz에 등록합니다.
+	 *
+	 * @return 채팅 플러시용 JobDetail 객체
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Bean
 	public JobDetail chatFlushJobDetail() {
 		return JobBuilder.newJob(ChatBatchQuartzLauncher.class)
-			.withIdentity("chatFlushQuartzJob", "chatGroup")
+			.withIdentity(JOB_NAME, GROUP_NAME)
 			.storeDurably()
 			.build();
 	}
 
+	/**
+	 * 채팅 플러시 트리거(Trigger)를 생성하여 지정된 간격으로 배치 작업을 실행하도록 설정합니다.
+	 *
+	 * @param chatFlushJobDetail 생성된 채팅 플러시 JobDetail
+	 * @return 배치 작업 실행을 위한 Trigger 객체
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Bean
 	public Trigger chatFlushTrigger(JobDetail chatFlushJobDetail) {
 		return TriggerBuilder.newTrigger()
 			.forJob(chatFlushJobDetail)
-			.withIdentity("chatFlushQuartzTrigger", "chatGroup")
+			.withIdentity(TRIGGER_NAME, GROUP_NAME)
 			.startNow()
 			.withSchedule(SimpleScheduleBuilder
 				.simpleSchedule()

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/listener/RedisAckListener.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/listener/RedisAckListener.java
@@ -1,0 +1,23 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.listener;
+
+
+import org.springframework.batch.core.ChunkListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.stereotype.Component;
+
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader.RedisStreamItemReader;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisAckListener implements ChunkListener {
+
+	private final RedisStreamItemReader reader;
+
+
+	@Override
+	public void afterChunk(ChunkContext context) {
+		reader.ackPending();
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/listener/RedisAckListener.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/listener/RedisAckListener.java
@@ -9,13 +9,24 @@ import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 배치 처리 후에 Redis 스트림 레코드를 ACK 처리하는 ChunkListener입니다.
+ *
+ * @since 2025-05-27
+ */
 @Component
 @RequiredArgsConstructor
 public class RedisAckListener implements ChunkListener {
 
 	private final RedisStreamItemReader reader;
 
-
+	/**
+	 * 청크 처리가 완료된 후 Redis 스트림 레코드를 ACK 처리합니다.
+	 *
+	 * @param context Chunk 처리 문맥
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Override
 	public void afterChunk(ChunkContext context) {
 		reader.ackPending();

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/processor/ChatMessageItemProcessor.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/processor/ChatMessageItemProcessor.java
@@ -1,0 +1,51 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.processor;
+
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity.ChatMessageEntity;
+import com.likelion.backendplus4.talkpick.batch.chat.model.ChatMessage;
+import com.likelion.backendplus4.talkpick.batch.chat.support.mapper.ChatMessageMapper;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Redis 스트림에서 읽은 레코드를 도메인 ChatMessage로 역직렬화한 후,
+ * 이를 ChatMessageEntity로 매핑하는 Processor 클래스입니다.
+ *
+ * @since 2025-05-27
+ */
+@Component
+@RequiredArgsConstructor
+public class ChatMessageItemProcessor
+	implements ItemProcessor<MapRecord<String,String,String>, ChatMessageEntity> {
+
+	private final ObjectMapper objectMapper;
+	private static final String PAYLOAD = "payload";
+
+	/**
+	 * Redis 스트림 레코드를 ChatMessage 도메인 객체로 변환하고,
+	 * 이를 JPA 엔티티로 매핑합니다.
+	 *
+	 * @param record Redis 스트림에서 읽은 MapRecord
+	 * @return 매핑된 ChatMessageEntity 객체
+	 * @throws ChatBatchException 변환 또는 매핑 중 오류 발생 시
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
+	@Override
+	public ChatMessageEntity process(MapRecord<String, String, String> record) {
+		try {
+			ChatMessage domain = objectMapper.readValue(
+				record.getValue().get(PAYLOAD), ChatMessage.class);
+			return ChatMessageMapper.toEntityFromDomain(domain);
+		} catch (Exception e) {
+			throw new ChatBatchException(
+				ChatBatchErrorCode.STREAM_READ_ERROR, e);
+		}
+	}
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -21,6 +21,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Component;
 
+import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -46,7 +49,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 	public RedisStreamItemReader(
 		RedisTemplate<String, String> redisTemplate,
-		@Value("${chat.flush.delay}") long blockMillis,
+		@Value("${chat.flush.interval}") long blockMillis,
 		@Value("${chat.flush.batch-size}") int batchSize) {
 		this.redisTemplate = redisTemplate;
 		this.blockMillis = blockMillis;
@@ -68,6 +71,18 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		this.buffer = null;
+	}
+
+	/**
+	 * Reader가 종료될 때 호출되어 내부 상태를 정리합니다.
+	 *
+	 * @throws ItemStreamException 종료 처리 중 예외 발생 시
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
+	@Override
+	public void close() throws ItemStreamException {
+		pendingToAck.clear();
 	}
 
 	/**
@@ -107,8 +122,9 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 * @since 2025-05-26
 	 */
 	public void ackPending() {
-		if (pendingToAck.isEmpty())
+		if (pendingToAck.isEmpty()) {
 			return;
+		}
 		pendingToAck.stream()
 			.collect(Collectors.groupingBy(MapRecord::getStream))
 			.forEach((streamKey, recList) -> {
@@ -117,7 +133,6 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 					.toArray(RecordId[]::new);
 				redisTemplate.opsForStream().acknowledge(streamKey, GROUP, ids);
 			});
-		pendingToAck.clear();
 	}
 
 	/**
@@ -213,9 +228,12 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 			redisTemplate.opsForStream()
 				.createGroup(streamKey, ReadOffset.from("0"), GROUP);
 		} catch (Exception ex) {
-			if (!String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
-				log.error("스트림 {}에 대한 컨슈머 그룹 생성에 실패했습니다.", streamKey, ex);
+			if (String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
+				return;
 			}
+			log.error("스트림 {}에 대한 컨슈머 그룹 생성에 실패했습니다.", streamKey, ex);
+			throw new ChatBatchException(ChatBatchErrorCode.REDIS_GROUP_CREATE_FAILED, ex);
 		}
 	}
+
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 import org.springframework.batch.item.ExecutionContext;
@@ -18,7 +19,6 @@ import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
-import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -46,14 +46,11 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	private static final int BATCH_SIZE = 100;
 
 	private Iterator<MapRecord<String, String, String>> buffer;
-	private final List<MapRecord<String, String, String>> pendingToAck = new java.util.ArrayList<>();
-	private final java.util.Set<String> initializedKeys = new java.util.HashSet<>();
+	private final List<MapRecord<String, String, String>> pendingToAck = new ArrayList<>();
 
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
-		// 리더 초기화: 버퍼 및 키 초기화
 		this.buffer = null;
-		this.initializedKeys.clear();
 	}
 
 	@Override
@@ -70,103 +67,14 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		return buffer.next();
 	}
 
-	private List<MapRecord<String, String, String>> fetchRecords() {
-		Set<String> keys = streamKeys();
-		if (keys.isEmpty()) {
-			return List.of();
-		}
-
-		// 새로 발견된 스트림마다 그룹 보장
-		keys.forEach(this::ensureGroup);
-
-		// 키별로 첫 호출이면 backlog(0)부터, 이후 호출이면 신규만
-		return keys.stream()
-			.flatMap(key -> {
-				if (initializedKeys.contains(key)) {
-					return fetchNewRecordsForKey(key).stream();
-				} else {
-					initializedKeys.add(key);
-					return fetchBacklogForKey(key).stream();
-				}
-			})
-			.toList();
-	}
-
-	private Set<String> streamKeys() {
-		return redisTemplate.keys(STREAM_KEY_PREFIX + "*");
-	}
-
-	private List<MapRecord<String, String, String>> fetchBacklogForKey(String key) {
-		log.debug("fetchBacklogForKey(): key={}, batchSize={}", key, BATCH_SIZE);
-		StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
-		List<MapRecord<String, String, String>> result = ops.read(
-			Consumer.from(GROUP, CONSUMER),
-			StreamReadOptions.empty().count(BATCH_SIZE),
-			StreamOffset.create(key, ReadOffset.from(">"))
-		);
-		log.debug("fetchBacklogForKey(): key={}, fetched pending size={}", key, result != null ? result.size() : 0);
-		return result == null ? List.of() : result;
-	}
-
-	private List<MapRecord<String, String, String>> fetchNewRecordsForKey(String key) {
-		StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
-
-		// 항상 마지막으로 소비된 이후 메시지부터 읽습니다.
-		ReadOffset offset = ReadOffset.lastConsumed();
-		log.debug("fetchNewRecordsForKey(): key={}, offset={}, batchSize={}, blockMillis={}",
-			key, offset, BATCH_SIZE, blockMillis);
-
-		List<MapRecord<String, String, String>> result = ops.read(
-			Consumer.from(GROUP, CONSUMER),
-			StreamReadOptions.empty()
-				.count(BATCH_SIZE)
-				.block(Duration.ofMillis(blockMillis / 2)),
-			StreamOffset.create(key, offset)
-		);
-		log.debug("fetchNewRecordsForKey(): key={}, fetched new size={}", key, result != null ? result.size() : 0);
-		return result == null ? List.of() : result;
-	}
-
-	private void ensureGroup(String streamKey) {
-		SetOperations<String, String> setOps = redisTemplate.opsForSet();
-		Long added = setOps.add(GROUP_SET_KEY, streamKey);
-
-		// 이미 기록된 경우에도 실제 그룹 존재 여부 확인
-		if (added != null && added == 0L && groupExists(streamKey)) {
-			return;
-		}
-		if (groupExists(streamKey)) {
-			return;
-		}
-
-		try {
-			redisTemplate.opsForStream()
-				.createGroup(streamKey, ReadOffset.from("0"), GROUP);
-			log.debug("Created consumer-group '{}' for stream '{}'", GROUP, streamKey);
-		} catch (Exception ex) {
-			if (!String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
-				log.error("Failed to create consumer group for stream {}", streamKey, ex);
-			}
-		}
-	}
-
-	private boolean groupExists(String streamKey) {
-		try {
-			List<org.springframework.data.redis.connection.stream.StreamInfo.XInfoGroup> groups = redisTemplate.opsForStream().groups(streamKey).toList();
-			return groups.stream().anyMatch(g -> GROUP.equals(g.groupName()));
-		} catch (Exception e) {
-			log.info(e.getLocalizedMessage());
-			return false;
-		}
-	}
-
 	/**
 	 * 읽어들인 레코드를 ACK 하여 재처리를 방지한다.
 	 *
 	 * @since 2025-05-26
 	 */
 	public void ackPending() {
-		if (pendingToAck.isEmpty()) return;
+		if (pendingToAck.isEmpty())
+			return;
 		pendingToAck.stream()
 			.collect(Collectors.groupingBy(MapRecord::getStream))
 			.forEach((streamKey, recList) -> {
@@ -176,5 +84,60 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 				redisTemplate.opsForStream().acknowledge(streamKey, GROUP, ids);
 			});
 		pendingToAck.clear();
+	}
+
+	private List<MapRecord<String, String, String>> fetchRecords() {
+		Set<String> keys = streamKeys();
+		if (keys.isEmpty()) {
+			return List.of();
+		}
+		keys.forEach(this::ensureGroup);
+
+		List<StreamOffset<String>> offsets = new ArrayList<>(keys.size());
+		keys.forEach(k -> offsets.add(StreamOffset.create(k, ReadOffset.lastConsumed())));
+
+		StreamReadOptions opts = StreamReadOptions.empty()
+			.count((long)BATCH_SIZE * keys.size())
+			.block(Duration.ofMillis(blockMillis / 2));
+
+		List<MapRecord<String, String, String>> result = getMapRecords(opts, offsets);
+		return result == null ? List.of() : result;
+	}
+
+	private List<MapRecord<String, String, String>> getMapRecords(StreamReadOptions opts,
+		List<StreamOffset<String>> offsets) {
+		return redisTemplate.opsForStream().read(Consumer.from(GROUP, CONSUMER),
+			opts,
+			offsets.toArray(new StreamOffset[0])
+		);
+	}
+
+	private Set<String> streamKeys() {
+		return redisTemplate.keys(STREAM_KEY_PREFIX + "*");
+	}
+
+	private void ensureGroup(String streamKey) {
+		SetOperations<String, String> setOps = redisTemplate.opsForSet();
+		Long added = setOps.add(GROUP_SET_KEY, streamKey);
+
+		if (added != null && added == 0L) {
+			return;
+		}
+
+		createGroupSafe(streamKey);
+	}
+
+	/**
+	 * 스트림 키에 대해 컨슈머 그룹을 생성합니다. BUSYGROUP 예외는 무시합니다.
+	 */
+	private void createGroupSafe(String streamKey) {
+		try {
+			redisTemplate.opsForStream()
+				.createGroup(streamKey, ReadOffset.from("0"), GROUP);
+		} catch (Exception ex) {
+			if (!String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
+				log.error("Failed to create consumer group for stream {}", streamKey, ex);
+			}
+		}
 	}
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -1,16 +1,21 @@
 package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
+import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
 
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Collections;
+import java.util.stream.Stream;
 
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -19,6 +24,11 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Redis 스트림에서 배치 처리용 레코드를 읽어오는 ItemStreamReader 구현체입니다.
+ *
+ * @since 2025-05-26
+ */
 @Component
 @RequiredArgsConstructor
 public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String, String, String>> {
@@ -33,33 +43,118 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	private static final String CONSUMER = "batch-reader";
 	private static final int BATCH_SIZE = 100;
 
-	private Iterator<MapRecord<String, String, String>> iterator;
-
+	/**
+	 * Redis 스트림으로부터 레코드를 한 개씩 읽어 반환합니다.
+	 *
+	 * @return 읽은 MapRecord 객체, 더 이상 읽을 레코드가 없으면 null
+	 * @since 2025-05-26
+	 * @author 박찬병
+	 */
 	@Override
 	public MapRecord<String, String, String> read() {
-		if (iterator != null && iterator.hasNext()) {
-			return iterator.next();
-		}
-		Set<String> keys = redisTemplate.keys(STREAM_KEY_PREFIX + "*");
-		if (keys.isEmpty()) {
+		List<MapRecord<String, String, String>> recs = fetchRecords();
+		if (recs.isEmpty()) {
 			return null;
 		}
+
+		MapRecord<String, String, String> record = recs.getFirst();
+		acknowledge(record.getStream(), List.of(record));
+
+		return record;
+	}
+
+	/**
+	 * 전체 스트림 키에 대해 보류 중인 레코드와 신규 레코드를 조회합니다.
+	 *
+	 * @return 모든 키의 레코드를 합친 List
+	 * @since 2025-05-26
+	 * @author 박찬병
+	 */
+	private List<MapRecord<String, String, String>> fetchRecords() {
+		Set<String> keys = getStreamKeys();
+		return keys.stream()
+			.flatMap(this::fetchRecordsForKey)
+			.toList();
+	}
+
+    /**
+     * 스트림 키 목록을 조회합니다.
+     *
+     * @return 스트림 키들의 Set
+     * @since 2025-05-26
+     * @author 박찬병
+     */
+    private Set<String> getStreamKeys() {
+        return redisTemplate.keys(STREAM_KEY_PREFIX + "*");
+    }
+
+
+    /**
+     * 단일 키에 대해 보류 중인 레코드와 신규 레코드를 스트림 형태로 결합하여 반환합니다.
+     *
+     * @param key 처리할 Redis 스트림 키
+     * @return 해당 키의 레코드 스트림
+     * @since 2025-05-26
+     * @author 박찬병
+     */
+    private Stream<MapRecord<String, String, String>> fetchRecordsForKey(String key) {
+        return Stream.concat(
+            fetchPendingRecordsForKey(key).stream(),
+            fetchNewRecordsForKey(key).stream()
+        );
+    }
+
+	/**
+	 * 주어진 키에 대한 보류(PENDING) 레코드를 조회합니다.
+	 *
+	 * @param key Redis 스트림 키
+	 * @return 보류 중인 레코드들의 List
+	 * @since 2025-05-26
+	 * @author 박찬병
+	 */
+	private List<MapRecord<String, String, String>> fetchPendingRecordsForKey(String key) {
+	    StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
+	    return Objects.requireNonNull(ops.read(
+			Consumer.from(GROUP, CONSUMER),
+			StreamReadOptions.empty().count(BATCH_SIZE),
+			StreamOffset.create(key, ReadOffset.from("0"))
+		)).stream().toList();
+	}
+
+	/**
+	 * 주어진 키에서 신규 레코드를 조회합니다.
+	 *
+	 * @param key Redis 스트림 키
+	 * @return 신규 레코드들의 List
+	 * @since 2025-05-26
+	 * @author 박찬병
+	 */
+	private List<MapRecord<String, String, String>> fetchNewRecordsForKey(String key) {
 		StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
-		List<MapRecord<String, String, String>> recs = keys.stream()
-			.flatMap(key -> Objects.requireNonNull(ops.read(
+		return Objects.requireNonNull(
+			ops.read(
 				Consumer.from(GROUP, CONSUMER),
 				StreamReadOptions.empty()
 					.count(BATCH_SIZE)
 					.block(Duration.ofMillis(blockMillis / 2)),
 				StreamOffset.create(key, ReadOffset.lastConsumed())
-			)).stream())
-			.toList();
+			)).stream().toList();
+	}
 
-		if (recs.isEmpty()) {
-			return null;
-		}
-		iterator = recs.iterator();
-		return iterator.next();
+
+	/**
+	 * 읽어들인 레코드를 ACK 하여 재처리를 방지한다.
+	 *
+	 * @param key     스트림 키
+	 * @param records 처리 완료된 레코드
+	 * @since 2025-05-26
+	 * @author 박찬병
+	 */
+	private void acknowledge(String key, List<MapRecord<String, String, String>> records) {
+		RecordId[] ids = records.stream()
+			.map(MapRecord::getId)
+			.toArray(RecordId[]::new);
+		redisTemplate.opsForStream().acknowledge(key, GROUP, ids);
 	}
 
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -190,7 +190,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 				.createGroup(streamKey, ReadOffset.from("0"), GROUP);
 		} catch (Exception ex) {
 			if (!String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
-				log.error("Failed to create consumer group for stream {}", streamKey, ex);
+				log.error("스트림 {}에 대한 컨슈머 그룹 생성에 실패했습니다.", streamKey, ex);
 			}
 		}
 	}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -1,15 +1,13 @@
 package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader;
-import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
-import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
 
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import java.util.Collections;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.stream.Consumer;
@@ -19,16 +17,19 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Redis 스트림에서 배치 처리용 레코드를 읽어오는 ItemStreamReader 구현체입니다.
  *
  * @since 2025-05-26
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String, String, String>> {
@@ -39,122 +40,141 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	private long blockMillis;
 
 	private static final String STREAM_KEY_PREFIX = "chat:stream:";
+	private static final String GROUP_SET_KEY = "chat:known-groups";
 	private static final String GROUP = "chatGroup";
 	private static final String CONSUMER = "batch-reader";
 	private static final int BATCH_SIZE = 100;
 
-	/**
-	 * Redis 스트림으로부터 레코드를 한 개씩 읽어 반환합니다.
-	 *
-	 * @return 읽은 MapRecord 객체, 더 이상 읽을 레코드가 없으면 null
-	 * @since 2025-05-26
-	 * @author 박찬병
-	 */
+	private Iterator<MapRecord<String, String, String>> buffer;
+	private final List<MapRecord<String, String, String>> pendingToAck = new java.util.ArrayList<>();
+	private final java.util.Set<String> initializedKeys = new java.util.HashSet<>();
+
 	@Override
-	public MapRecord<String, String, String> read() {
-		List<MapRecord<String, String, String>> recs = fetchRecords();
-		if (recs.isEmpty()) {
-			return null;
-		}
-
-		MapRecord<String, String, String> record = recs.getFirst();
-		acknowledge(record.getStream(), List.of(record));
-
-		return record;
+	public void open(ExecutionContext executionContext) throws ItemStreamException {
+		// 리더 초기화: 버퍼 및 키 초기화
+		this.buffer = null;
+		this.initializedKeys.clear();
 	}
 
-	/**
-	 * 전체 스트림 키에 대해 보류 중인 레코드와 신규 레코드를 조회합니다.
-	 *
-	 * @return 모든 키의 레코드를 합친 List
-	 * @since 2025-05-26
-	 * @author 박찬병
-	 */
+	@Override
+	public MapRecord<String, String, String> read() {
+		if (buffer == null || !buffer.hasNext()) {
+			List<MapRecord<String, String, String>> recs = fetchRecords();
+			log.info("읽어온 recs = {}", recs.size());
+			if (recs.isEmpty()) {
+				return null;
+			}
+			pendingToAck.addAll(recs);
+			buffer = recs.iterator();
+		}
+		return buffer.next();
+	}
+
 	private List<MapRecord<String, String, String>> fetchRecords() {
-		Set<String> keys = getStreamKeys();
+		Set<String> keys = streamKeys();
+		if (keys.isEmpty()) {
+			return List.of();
+		}
+
+		// 새로 발견된 스트림마다 그룹 보장
+		keys.forEach(this::ensureGroup);
+
+		// 키별로 첫 호출이면 backlog(0)부터, 이후 호출이면 신규만
 		return keys.stream()
-			.flatMap(this::fetchRecordsForKey)
+			.flatMap(key -> {
+				if (initializedKeys.contains(key)) {
+					return fetchNewRecordsForKey(key).stream();
+				} else {
+					initializedKeys.add(key);
+					return fetchBacklogForKey(key).stream();
+				}
+			})
 			.toList();
 	}
 
-    /**
-     * 스트림 키 목록을 조회합니다.
-     *
-     * @return 스트림 키들의 Set
-     * @since 2025-05-26
-     * @author 박찬병
-     */
-    private Set<String> getStreamKeys() {
-        return redisTemplate.keys(STREAM_KEY_PREFIX + "*");
-    }
+	private Set<String> streamKeys() {
+		return redisTemplate.keys(STREAM_KEY_PREFIX + "*");
+	}
 
-
-    /**
-     * 단일 키에 대해 보류 중인 레코드와 신규 레코드를 스트림 형태로 결합하여 반환합니다.
-     *
-     * @param key 처리할 Redis 스트림 키
-     * @return 해당 키의 레코드 스트림
-     * @since 2025-05-26
-     * @author 박찬병
-     */
-    private Stream<MapRecord<String, String, String>> fetchRecordsForKey(String key) {
-        return Stream.concat(
-            fetchPendingRecordsForKey(key).stream(),
-            fetchNewRecordsForKey(key).stream()
-        );
-    }
-
-	/**
-	 * 주어진 키에 대한 보류(PENDING) 레코드를 조회합니다.
-	 *
-	 * @param key Redis 스트림 키
-	 * @return 보류 중인 레코드들의 List
-	 * @since 2025-05-26
-	 * @author 박찬병
-	 */
-	private List<MapRecord<String, String, String>> fetchPendingRecordsForKey(String key) {
-	    StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
-	    return Objects.requireNonNull(ops.read(
+	private List<MapRecord<String, String, String>> fetchBacklogForKey(String key) {
+		log.debug("fetchBacklogForKey(): key={}, batchSize={}", key, BATCH_SIZE);
+		StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
+		List<MapRecord<String, String, String>> result = ops.read(
 			Consumer.from(GROUP, CONSUMER),
 			StreamReadOptions.empty().count(BATCH_SIZE),
-			StreamOffset.create(key, ReadOffset.from("0"))
-		)).stream().toList();
+			StreamOffset.create(key, ReadOffset.from(">"))
+		);
+		log.debug("fetchBacklogForKey(): key={}, fetched pending size={}", key, result != null ? result.size() : 0);
+		return result == null ? List.of() : result;
 	}
 
-	/**
-	 * 주어진 키에서 신규 레코드를 조회합니다.
-	 *
-	 * @param key Redis 스트림 키
-	 * @return 신규 레코드들의 List
-	 * @since 2025-05-26
-	 * @author 박찬병
-	 */
 	private List<MapRecord<String, String, String>> fetchNewRecordsForKey(String key) {
 		StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
-		return Objects.requireNonNull(
-			ops.read(
-				Consumer.from(GROUP, CONSUMER),
-				StreamReadOptions.empty()
-					.count(BATCH_SIZE)
-					.block(Duration.ofMillis(blockMillis / 2)),
-				StreamOffset.create(key, ReadOffset.lastConsumed())
-			)).stream().toList();
+
+		// 항상 마지막으로 소비된 이후 메시지부터 읽습니다.
+		ReadOffset offset = ReadOffset.lastConsumed();
+		log.debug("fetchNewRecordsForKey(): key={}, offset={}, batchSize={}, blockMillis={}",
+			key, offset, BATCH_SIZE, blockMillis);
+
+		List<MapRecord<String, String, String>> result = ops.read(
+			Consumer.from(GROUP, CONSUMER),
+			StreamReadOptions.empty()
+				.count(BATCH_SIZE)
+				.block(Duration.ofMillis(blockMillis / 2)),
+			StreamOffset.create(key, offset)
+		);
+		log.debug("fetchNewRecordsForKey(): key={}, fetched new size={}", key, result != null ? result.size() : 0);
+		return result == null ? List.of() : result;
 	}
 
+	private void ensureGroup(String streamKey) {
+		SetOperations<String, String> setOps = redisTemplate.opsForSet();
+		Long added = setOps.add(GROUP_SET_KEY, streamKey);
+
+		// 이미 기록된 경우에도 실제 그룹 존재 여부 확인
+		if (added != null && added == 0L && groupExists(streamKey)) {
+			return;
+		}
+		if (groupExists(streamKey)) {
+			return;
+		}
+
+		try {
+			redisTemplate.opsForStream()
+				.createGroup(streamKey, ReadOffset.from("0"), GROUP);
+			log.debug("Created consumer-group '{}' for stream '{}'", GROUP, streamKey);
+		} catch (Exception ex) {
+			if (!String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
+				log.error("Failed to create consumer group for stream {}", streamKey, ex);
+			}
+		}
+	}
+
+	private boolean groupExists(String streamKey) {
+		try {
+			List<org.springframework.data.redis.connection.stream.StreamInfo.XInfoGroup> groups = redisTemplate.opsForStream().groups(streamKey).toList();
+			return groups.stream().anyMatch(g -> GROUP.equals(g.groupName()));
+		} catch (Exception e) {
+			log.info(e.getLocalizedMessage());
+			return false;
+		}
+	}
 
 	/**
 	 * 읽어들인 레코드를 ACK 하여 재처리를 방지한다.
 	 *
-	 * @param key     스트림 키
-	 * @param records 처리 완료된 레코드
 	 * @since 2025-05-26
-	 * @author 박찬병
 	 */
-	private void acknowledge(String key, List<MapRecord<String, String, String>> records) {
-		RecordId[] ids = records.stream()
-			.map(MapRecord::getId)
-			.toArray(RecordId[]::new);
-		redisTemplate.opsForStream().acknowledge(key, GROUP, ids);
+	public void ackPending() {
+		if (pendingToAck.isEmpty()) return;
+		pendingToAck.stream()
+			.collect(Collectors.groupingBy(MapRecord::getStream))
+			.forEach((streamKey, recList) -> {
+				RecordId[] ids = recList.stream()
+					.map(MapRecord::getId)
+					.toArray(RecordId[]::new);
+				redisTemplate.opsForStream().acknowledge(streamKey, GROUP, ids);
+			});
+		pendingToAck.clear();
 	}
-
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -21,7 +21,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Component;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,31 +30,53 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String, String, String>> {
 
-	private final RedisTemplate<String, String> redisTemplate;
-
-	@Value("${chat.flush.delay}")
-	private long blockMillis;
-
-	private static final String STREAM_KEY_PREFIX = "chat:stream:";
+	private static final String STREAM_KEY_PREFIX = "chat:stream:*";
 	private static final String GROUP_SET_KEY = "chat:known-groups";
 	private static final String GROUP = "chatGroup";
 	private static final String CONSUMER = "batch-reader";
-	private static final int BATCH_SIZE = 100;
+
+	private final int batchSize;
+	private final long blockMillis;
 
 	private Iterator<MapRecord<String, String, String>> buffer;
+	private final RedisTemplate<String, String> redisTemplate;
 	private final List<MapRecord<String, String, String>> pendingToAck = new ArrayList<>();
 
+	public RedisStreamItemReader(
+		RedisTemplate<String, String> redisTemplate,
+		@Value("${chat.flush.delay}") long blockMillis,
+		@Value("${chat.flush.batch-size}") int batchSize) {
+		this.redisTemplate = redisTemplate;
+		this.blockMillis = blockMillis;
+		this.batchSize = batchSize;
+	}
+
+
+	/**
+	 * Batch 실행 시 이전 실행 상태에 관계없이 reader를 초기화합니다.
+	 *
+	 * @param executionContext 현재 스텝의 ExecutionContext
+	 * @throws ItemStreamException 초기화 실패 시 발생
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		this.buffer = null;
 	}
 
+	/**
+	 * Redis 스트림에서 배치 처리용 레코드를 한 개씩 읽어 반환합니다.
+	 *
+	 * @return 읽은 MapRecord 객체, 더 이상 읽을 레코드가 없으면 null
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	@Override
 	public MapRecord<String, String, String> read() {
-		if (buffer == null || !buffer.hasNext()) {
+		if (null == buffer || !buffer.hasNext()) {
 			List<MapRecord<String, String, String>> recs = fetchRecords();
 			log.info("읽어온 recs = {}", recs.size());
 			if (recs.isEmpty()) {
@@ -68,7 +89,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	}
 
 	/**
-	 * 읽어들인 레코드를 ACK 하여 재처리를 방지한다.
+	 * 읽어들인 레코드를 ACK 하여 재처리를 방지합니다.
 	 *
 	 * @since 2025-05-26
 	 */
@@ -86,6 +107,13 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		pendingToAck.clear();
 	}
 
+	/**
+	 * 스트림 키 목록에서 레코드를 조회하여 반환합니다.
+	 *
+	 * @return 조회된 MapRecord 리스트, 없으면 빈 리스트
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	private List<MapRecord<String, String, String>> fetchRecords() {
 		Set<String> keys = streamKeys();
 		if (keys.isEmpty()) {
@@ -97,13 +125,21 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		keys.forEach(k -> offsets.add(StreamOffset.create(k, ReadOffset.lastConsumed())));
 
 		StreamReadOptions opts = StreamReadOptions.empty()
-			.count((long)BATCH_SIZE * keys.size())
+			.count((long) batchSize * keys.size())
 			.block(Duration.ofMillis(blockMillis / 2));
 
-		List<MapRecord<String, String, String>> result = getMapRecords(opts, offsets);
-		return result == null ? List.of() : result;
+		return getMapRecords(opts, offsets);
 	}
 
+	/**
+	 * 주어진 StreamReadOptions와 offsets로부터 MapRecord를 읽어 반환합니다.
+	 *
+	 * @param opts    스트림 읽기 옵션
+	 * @param offsets 읽기를 수행할 StreamOffset 리스트
+	 * @return 읽어온 MapRecord 리스트
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	private List<MapRecord<String, String, String>> getMapRecords(StreamReadOptions opts,
 		List<StreamOffset<String>> offsets) {
 		return redisTemplate.opsForStream().read(Consumer.from(GROUP, CONSUMER),
@@ -112,15 +148,29 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		);
 	}
 
+	/**
+	 * 사용 가능한 Redis 스트림 키들을 조회합니다.
+	 *
+	 * @return 스트림 키 세트
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	private Set<String> streamKeys() {
-		return redisTemplate.keys(STREAM_KEY_PREFIX + "*");
+		return redisTemplate.keys(STREAM_KEY_PREFIX);
 	}
 
+	/**
+	 * 스트림 키에 대해 컨슈머 그룹을 생성하거나 이미 존재하면 무시합니다.
+	 *
+	 * @param streamKey 대상 스트림 키
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
 	private void ensureGroup(String streamKey) {
 		SetOperations<String, String> setOps = redisTemplate.opsForSet();
 		Long added = setOps.add(GROUP_SET_KEY, streamKey);
 
-		if (added != null && added == 0L) {
+		if (null != added && 0L == added) {
 			return;
 		}
 
@@ -129,6 +179,10 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 	/**
 	 * 스트림 키에 대해 컨슈머 그룹을 생성합니다. BUSYGROUP 예외는 무시합니다.
+	 *
+	 * @param streamKey 대상 스트림 키
+	 * @author 박찬병
+	 * @since 2025-05-27
 	 */
 	private void createGroupSafe(String streamKey) {
 		try {

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -55,10 +55,13 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 
 	/**
-	 * Batch 실행 시 이전 실행 상태에 관계없이 reader를 초기화합니다.
+	 * Reader 상태를 초기화합니다.
+	 *
+	 * 1. 이전 배치 실행에서 남아 있을 수 있는 {@code buffer} iterator를 {@code null}로 설정합니다.
+	 * 2. 다음 {@code read()} 호출 시 새로 레코드를 조회하도록 강제합니다.
 	 *
 	 * @param executionContext 현재 스텝의 ExecutionContext
-	 * @throws ItemStreamException 초기화 실패 시 발생
+	 * @throws ItemStreamException 초기화 실패 시
 	 * @author 박찬병
 	 * @since 2025-05-27
 	 */
@@ -68,9 +71,14 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	}
 
 	/**
-	 * Redis 스트림에서 배치 처리용 레코드를 한 개씩 읽어 반환합니다.
+	 * Redis 스트림에서 레코드를 순차적으로 읽어옵니다.
 	 *
-	 * @return 읽은 MapRecord 객체, 더 이상 읽을 레코드가 없으면 null
+	 * 1. {@code buffer}가 비어있거나 더 이상 요소가 없으면 {@link #fetchRecords()}를 호출하여 새 레코드 묶음을 가져옵니다.
+	 * 2. 가져온 레코드가 없으면 {@code null}을 반환하여 Step이 종료되도록 합니다.
+	 * 3. 레코드가 존재하면 {@code pendingToAck}에 추가하고 {@code buffer}를 새 iterator로 초기화합니다.
+	 * 4. {@code buffer.next()}를 호출해 다음 레코드를 반환합니다.
+	 *
+	 * @return 다음 MapRecord, 더 이상 없으면 {@code null}
 	 * @author 박찬병
 	 * @since 2025-05-27
 	 */
@@ -89,8 +97,13 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	}
 
 	/**
-	 * 읽어들인 레코드를 ACK 하여 재처리를 방지합니다.
+	 * 읽어들인 레코드들을 일괄 ACK 처리합니다.
 	 *
+	 * 1. {@code pendingToAck}가 비어있으면 즉시 반환합니다.
+	 * 2. 스트림별로 레코드를 그룹화하여 동일 스트림에 대해 한 번의 호출로 ACK 합니다.
+	 * 3. ACK 후 {@code pendingToAck} 리스트를 비워 재처리를 방지합니다.
+	 *
+	 * @author 박찬병
 	 * @since 2025-05-26
 	 */
 	public void ackPending() {
@@ -108,7 +121,14 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	}
 
 	/**
-	 * 스트림 키 목록에서 레코드를 조회하여 반환합니다.
+	 * 활성 스트림 키에서 새 레코드 묶음을 조회합니다.
+	 *
+	 * 1. {@link #streamKeys()}로 스트림 키 세트를 가져옵니다.
+	 * 2. 키가 없으면 빈 리스트를 반환합니다.
+	 * 3. 각 키에 대해 {@link #ensureGroup(String)}로 컨슈머 그룹을 보장합니다.
+	 * 4. 모든 키를 대상으로 마지막으로 소비한 이후 항목부터 읽도록 {@code offsets}를 구성합니다.
+	 * 5. {@code blockMillis}의 절반 동안 블로킹하며 최대 {@code batchSize * keys.size()} 만큼 읽습니다.
+	 * 6. 읽어온 레코드 리스트를 반환합니다.
 	 *
 	 * @return 조회된 MapRecord 리스트, 없으면 빈 리스트
 	 * @author 박찬병
@@ -160,7 +180,11 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	}
 
 	/**
-	 * 스트림 키에 대해 컨슈머 그룹을 생성하거나 이미 존재하면 무시합니다.
+	 * 주어진 스트림 키에 대한 컨슈머 그룹을 보장합니다.
+	 *
+	 * 1. Redis SET({@code chat:known-groups})을 통해 이미 그룹을 생성한 스트림인지 확인합니다.
+	 * 2. 처음 보는 스트림이면 {@link #createGroupSafe(String)}를 호출해 그룹을 생성합니다.
+	 * 3. 이미 존재한다면 아무 작업도 수행하지 않습니다.
 	 *
 	 * @param streamKey 대상 스트림 키
 	 * @author 박찬병

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -1,0 +1,65 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.batch.reader;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String, String, String>> {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Value("${chat.flush.delay}")
+	private long blockMillis;
+
+	private static final String STREAM_KEY_PREFIX = "chat:stream:";
+	private static final String GROUP = "chatGroup";
+	private static final String CONSUMER = "batch-reader";
+	private static final int BATCH_SIZE = 100;
+
+	private Iterator<MapRecord<String, String, String>> iterator;
+
+	@Override
+	public MapRecord<String, String, String> read() {
+		if (iterator != null && iterator.hasNext()) {
+			return iterator.next();
+		}
+		Set<String> keys = redisTemplate.keys(STREAM_KEY_PREFIX + "*");
+		if (keys.isEmpty()) {
+			return null;
+		}
+		StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
+		List<MapRecord<String, String, String>> recs = keys.stream()
+			.flatMap(key -> Objects.requireNonNull(ops.read(
+				Consumer.from(GROUP, CONSUMER),
+				StreamReadOptions.empty()
+					.count(BATCH_SIZE)
+					.block(Duration.ofMillis(blockMillis / 2)),
+				StreamOffset.create(key, ReadOffset.lastConsumed())
+			)).stream())
+			.toList();
+
+		if (recs.isEmpty()) {
+			return null;
+		}
+		iterator = recs.iterator();
+		return iterator.next();
+	}
+
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/jpa/entity/ChatMessageEntity.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/jpa/entity/ChatMessageEntity.java
@@ -1,0 +1,47 @@
+package com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Table(name = "chat_message")
+public class ChatMessageEntity {
+	@Id
+	@GeneratedValue(generator = "msg_seq_gen")
+	@GenericGenerator(
+		name = "msg_seq_gen",
+		strategy = "enhanced-sequence",
+		parameters = {
+			@Parameter(name = "optimizer",       value = "pooled-lo"),
+			@Parameter(name = "initial_value",   value = "1"),
+			@Parameter(name = "increment_size",  value = "50")
+		}
+	)
+	@Column(name = "chat_message_id")
+	private Long id;
+	@Column(name = "article_id")
+	private String articleId;
+	@Column(name = "sender")
+	private String sender;
+	@Column(name = "content")
+	private String content;
+	@Column(name = "timestamp")
+	private LocalDateTime timestamp;
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/model/ChatMessage.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/model/ChatMessage.java
@@ -1,0 +1,32 @@
+package com.likelion.backendplus4.talkpick.batch.chat.model;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessage {
+    private final Long chatId;
+    private final String articleId;
+    private final String sender;
+    private final String content;
+    private final LocalDateTime timestamp;
+    private final MessageType messageType;
+
+    // public ChatMessage(Long chatId, String articleId, String sender, String content,LocalDateTime timestamp, MessageType messageType) {
+    //     if(articleId == null || articleId.isEmpty()) {
+    //         throw new ChatException(ChatErrorCode.INVALID_ARTICLE_ID);
+    //     }
+    //     if(sender == null || sender.isEmpty()) {
+    //         throw new ChatException(ChatErrorCode.INVALID_SENDER);
+    //     }
+    //     this.chatId = chatId;
+    //     this.articleId = articleId;
+    //     this.sender = sender;
+    //     this.content = content;
+    //     this.timestamp = timestamp;
+    //     this.messageType = messageType;
+    // }
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/model/ChatMessage.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/model/ChatMessage.java
@@ -15,18 +15,4 @@ public class ChatMessage {
     private final LocalDateTime timestamp;
     private final MessageType messageType;
 
-    // public ChatMessage(Long chatId, String articleId, String sender, String content,LocalDateTime timestamp, MessageType messageType) {
-    //     if(articleId == null || articleId.isEmpty()) {
-    //         throw new ChatException(ChatErrorCode.INVALID_ARTICLE_ID);
-    //     }
-    //     if(sender == null || sender.isEmpty()) {
-    //         throw new ChatException(ChatErrorCode.INVALID_SENDER);
-    //     }
-    //     this.chatId = chatId;
-    //     this.articleId = articleId;
-    //     this.sender = sender;
-    //     this.content = content;
-    //     this.timestamp = timestamp;
-    //     this.messageType = messageType;
-    // }
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/model/MessageType.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/model/MessageType.java
@@ -1,0 +1,7 @@
+package com.likelion.backendplus4.talkpick.batch.chat.model;
+
+public enum MessageType {
+    CHAT,
+    JOIN,
+    LEAVE
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/support/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/support/mapper/ChatMessageMapper.java
@@ -1,0 +1,31 @@
+package com.likelion.backendplus4.talkpick.batch.chat.support.mapper;
+
+import com.likelion.backendplus4.talkpick.batch.chat.infrastructure.adapter.out.jpa.entity.ChatMessageEntity;
+import com.likelion.backendplus4.talkpick.batch.chat.model.ChatMessage;
+
+/**
+ * Chat 관련 매퍼 클래스입니다.
+ *
+ * @since 2025-05-26
+ */
+public class ChatMessageMapper {
+
+	/**
+	 * ChatMessage 도메인 객체를 ChatMessageEntity 엔티티 객체로 변환합니다.
+	 *
+	 * @param chatMessage 변환할 ChatMessage 도메인 객체
+	 * @return 변환된 ChatMessageEntity 엔티티 객체
+	 *
+	 * @author 박찬병
+	 * @since 2025-05-26
+	 */
+	public static ChatMessageEntity toEntityFromDomain(ChatMessage chatMessage) {
+		return ChatMessageEntity.builder()
+			.articleId(chatMessage.getArticleId())
+			.sender(chatMessage.getSender())
+			.content(chatMessage.getContent())
+			.timestamp(chatMessage.getTimestamp())
+			.build();
+	}
+
+}

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/common/configuration/redis/RedisConfig.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/common/configuration/redis/RedisConfig.java
@@ -1,0 +1,48 @@
+package com.likelion.backendplus4.talkpick.batch.common.configuration.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+/**
+ * Redis 설정을 담당하는 Configuration 클래스입니다.
+ *
+ * @since 2025-05-12
+ * @modified 2025-05-12
+ */
+@Configuration
+public class RedisConfig {
+    
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    /**
+     * RedisConnectionFactory를 구성합니다.
+     * application.yml에 설정된 host와 port 정보를 사용하여 LettuceConnectionFactory를 생성합니다.
+     *
+     * @return LettuceConnectionFactory 객체
+     * @author 박찬병
+     * @since 2025-05-12
+     * @modified 2025-05-12
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(host);
+        redisConfig.setPort(port);
+        redisConfig.setPassword(RedisPassword.of(password));
+    
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,3 +98,4 @@ management:
 chat:
   flush:
     delay: 30000
+    batch-size: 100

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,5 +97,5 @@ management:
 
 chat:
   flush:
-    delay: ${CHAT_BATCH_DELAY:30000}
+    interval: ${CHAT_BATCH_INTERVAL:30000}
     batch-size: ${CHAT_BATCH_SIZE:100}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -97,5 +97,5 @@ management:
 
 chat:
   flush:
-    delay: 30000
-    batch-size: 100
+    delay: ${CHAT_BATCH_DELAY:30000}
+    batch-size: ${CHAT_BATCH_SIZE:100}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,12 @@ spring:
       cron: "0 */1 * * * ?"
     article-embedding:
       cron: "0 */5 * * * ?"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+
 
 log:
   rolling:
@@ -88,3 +94,7 @@ management:
         http:
           server:
             requests: 'true'
+
+chat:
+  flush:
+    delay: 30000


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결


## ✨ 변경 사항

| 구분 | 설명 |
|------|------|
| **Batch 파이프라인 구축** | Redis Stream → Spring Batch → JPA 저장 전체 흐름 신규 도입 |
| `ChatMessageItemProcessor` | `MapRecord` payload(JSON) → `ChatMessage` 도메인 → `ChatMessageEntity` 매핑 |
| `RedisAckListener` | 청크 커밋 직후 `ackPending()` 호출로 Stream ACK 처리 |
| `ChatBatchConfig` | *Step*(`chatFlushStep`)·*Job*(`chatFlushJob`) 정의 <br>  • chunk size 100 <br>  • `JpaItemWriter`(`persist`) 사용 <br>  • `faultTolerant()` + `retry(ChatBatchException).limit(3)` |
| `ChatBatchQuartzLauncher` | Quartz `Job` → `jobLauncher.run(chatFlushJob)` 실행 래퍼 |
| `QuartzChatConfig` | Quartz JobDetail/Trigger 생성 <br>  • 주기: `${chat.flush.delay}` (ms) |


## 🔍 리뷰어에게
1. **ACK 타이밍** – `afterChunk` 시점 ACK이 적절한지 검토해 주세요. (대안: `afterChunkError` 추가 여부)  
2. **Retry 정책** – `retryLimit(3)`이 충분한지, Back-off 필요 여부 논의 부탁드립니다.  
3. **스케줄 주기** – `chat.flush.delay` 기본값/운영값 검증 필요합니다. 


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈

- closed #87 