### PR TITLE
✨ Feature/#92 pending 메시지 처리

### DIFF
--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -47,11 +47,12 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 	private final int batchSize;
 	private final long blockMillis;
-
-	private Iterator<MapRecord<String, String, String>> buffer;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final StreamOperations<String, String, String> streamOperations;
 	private final List<MapRecord<String, String, String>> pendingToAck = new ArrayList<>();
+
+	private Iterator<MapRecord<String, String, String>> buffer;;
+	private Set<String> currentStreamKeys;
 
 	public RedisStreamItemReader(
 		RedisTemplate<String, String> redisTemplate,
@@ -78,7 +79,8 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		this.buffer = null;
-		claimOldPendingMessages();
+		this.currentStreamKeys = streamKeys();
+		claimOldPendingMessages(this.currentStreamKeys);
 
 	}
 
@@ -97,7 +99,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	/**
 	 * Redis 스트림에서 레코드를 순차적으로 읽어옵니다.
 	 *
-	 * 1. {@code buffer}가 비어있거나 더 이상 요소가 없으면 {@link #fetchRecords()}를 호출하여 새 레코드 묶음을 가져옵니다.
+	 * 1. {@code buffer}가 비어있거나 더 이상 요소가 없으면 {@link #fetchRecords(Set)}를 호출하여 새 레코드 묶음을 가져옵니다.
 	 * 2. 가져온 레코드가 없으면 {@code null}을 반환하여 Step이 종료되도록 합니다.
 	 * 3. 레코드가 존재하면 {@code pendingToAck}에 추가하고 {@code buffer}를 새 iterator로 초기화합니다.
 	 * 4. {@code buffer.next()}를 호출해 다음 레코드를 반환합니다.
@@ -109,7 +111,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public MapRecord<String, String, String> read() {
 		if (null == buffer || !buffer.hasNext()) {
-			List<MapRecord<String, String, String>> recs = fetchRecords();
+			List<MapRecord<String, String, String>> recs = fetchRecords(currentStreamKeys);
 			log.info("읽어온 recs = {}", recs.size());
 			if (recs.isEmpty()) {
 				return null;
@@ -145,6 +147,44 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	}
 
 	/**
+	 * 사용 가능한 Redis 스트림 키들을 조회합니다.
+	 *
+	 * @return 스트림 키 세트
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
+	private Set<String> streamKeys() {
+		return redisTemplate.keys(STREAM_KEY_PREFIX);
+	}
+
+
+	@EntryExitLog
+	private void claimOldPendingMessages(Set<String> keys) {
+		if (keys.isEmpty()) return;
+
+		for (String streamKey : keys) {
+			try {
+				PendingMessages pending = streamOperations
+					.pending(streamKey, Consumer.from(GROUP, CONSUMER), Range.unbounded(), 100L);
+
+				List<RecordId> idsList = new ArrayList<>();
+				for (PendingMessage pm : pending) {
+					idsList.add(pm.getId());
+				}
+				RecordId[] ids = idsList.toArray(new RecordId[0]);
+
+				if (ids.length > 0) {
+					List<MapRecord<String, String, String>> claimedRaw = streamOperations
+						.claim(streamKey, GROUP, CONSUMER, Duration.ofMillis(0), ids);
+					pendingToAck.addAll(claimedRaw);
+				}
+			} catch (Exception e) {
+				log.warn("Pending 메시지 클레임 실패: streamKey={}, error={}", streamKey, e.getMessage());
+			}
+		}
+	}
+
+	/**
 	 * 활성 스트림 키에서 새 레코드 묶음을 조회합니다.
 	 *
 	 * 1. {@link #streamKeys()}로 스트림 키 세트를 가져옵니다.
@@ -158,8 +198,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 * @author 박찬병
 	 * @since 2025-05-27
 	 */
-	private List<MapRecord<String, String, String>> fetchRecords() {
-		Set<String> keys = streamKeys();
+	private List<MapRecord<String, String, String>> fetchRecords(Set<String> keys) {
 		if (keys.isEmpty()) {
 			return List.of();
 		}
@@ -190,17 +229,6 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 			opts,
 			offsets.toArray(new StreamOffset[0])
 		);
-	}
-
-	/**
-	 * 사용 가능한 Redis 스트림 키들을 조회합니다.
-	 *
-	 * @return 스트림 키 세트
-	 * @author 박찬병
-	 * @since 2025-05-27
-	 */
-	private Set<String> streamKeys() {
-		return redisTemplate.keys(STREAM_KEY_PREFIX);
 	}
 
 	/**
@@ -244,31 +272,5 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		}
 	}
 
-	@EntryExitLog
-	private void claimOldPendingMessages() {
-		Set<String> keys = streamKeys();
-		if (keys.isEmpty()) return;
-
-		for (String streamKey : keys) {
-			try {
-				PendingMessages pending = streamOperations
-					.pending(streamKey, Consumer.from(GROUP, CONSUMER), Range.unbounded(), 100L);
-
-				List<RecordId> idsList = new ArrayList<>();
-				for (PendingMessage pm : pending) {
-					idsList.add(pm.getId());
-				}
-				RecordId[] ids = idsList.toArray(new RecordId[0]);
-
-				if (ids.length > 0) {
-					List<MapRecord<String, String, String>> claimedRaw = streamOperations
-						.claim(streamKey, GROUP, CONSUMER, Duration.ofMillis(0), ids);
-					pendingToAck.addAll(claimedRaw);
-				}
-			} catch (Exception e) {
-				log.warn("Pending 메시지 클레임 실패: streamKey={}, error={}", streamKey, e.getMessage());
-			}
-		}
-	}
 
 }

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -52,9 +52,8 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	private final RedisTemplate<String, String> redisTemplate;
 	private final StreamOperations<String, String, String> streamOperations;
 	private final List<MapRecord<String, String, String>> pendingToAck = new ArrayList<>();
-	private int pendingReadIndex = 0;
 
-	private Iterator<MapRecord<String, String, String>> buffer;;
+	private Iterator<MapRecord<String, String, String>> buffer;
 	private Set<String> currentStreamKeys;
 
 	public RedisStreamItemReader(
@@ -83,8 +82,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		this.buffer = null;
 		this.currentStreamKeys = streamKeys();
-		claimOldPendingMessages(this.currentStreamKeys);
-
+		claimOldPendingMessages();
 	}
 
 	/**
@@ -97,13 +95,12 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public void close() throws ItemStreamException {
 		pendingToAck.clear();
-		pendingReadIndex = 0;
 	}
 
 	/**
 	 * Redis 스트림에서 레코드를 순차적으로 읽어옵니다.
 	 *
-	 * 1. {@code buffer}가 비어있거나 더 이상 요소가 없으면 {@link #fetchRecords(Set)}를 호출하여 새 레코드 묶음을 가져옵니다.
+	 * 1. {@code buffer}가 비어있거나 더 이상 요소가 없으면 {@link #fetchRecords()}를 호출하여 새 레코드 묶음을 가져옵니다.
 	 * 2. 가져온 레코드가 없으면 {@code null}을 반환하여 Step이 종료되도록 합니다.
 	 * 3. 레코드가 존재하면 {@code pendingToAck}에 추가하고 {@code buffer}를 새 iterator로 초기화합니다.
 	 * 4. {@code buffer.next()}를 호출해 다음 레코드를 반환합니다.
@@ -115,7 +112,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public MapRecord<String, String, String> read() {
 		if (buffer == null || !buffer.hasNext()) {
-			List<MapRecord<String, String, String>> recs = fetchRecords(currentStreamKeys);
+			List<MapRecord<String, String, String>> recs = fetchRecords();
 			log.info("읽어온 recs = {}", recs.size());
 			if (recs.isEmpty()) {
 				return null;
@@ -148,7 +145,6 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 					.toArray(RecordId[]::new);
 				streamOperations.acknowledge(streamKey, GROUP, ids);
 			});
-		// After acknowledging all pendingToAck entries, clear the list and reset index
 		pendingToAck.clear();
 	}
 
@@ -163,37 +159,30 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		return redisTemplate.keys(STREAM_KEY_PREFIX);
 	}
 
-
+	/**
+	 * 활성 스트림 키들에 대해 기존에 PENDING 상태로 남아 있는 메시지를 클레임하여 처리합니다.
+	 *
+	 * @author 박찬병
+	 * @since 2025-06-02
+	 */
 	@EntryExitLog
-	private void claimOldPendingMessages(Set<String> keys) {
-		if (keys.isEmpty()) {
+	private void claimOldPendingMessages() {
+		if (currentStreamKeys == null || currentStreamKeys.isEmpty()) {
 			return;
 		}
-
-		for (String streamKey : keys) {
+		for (String streamKey : currentStreamKeys) {
 			try {
-				PendingMessages pending = streamOperations
-					.pending(streamKey, Consumer.from(GROUP, CONSUMER), Range.unbounded(), 100L);
-
-				List<RecordId> idsList = new ArrayList<>();
-				for (PendingMessage pm : pending) {
-					idsList.add(pm.getId());
-				}
-				RecordId[] ids = idsList.toArray(new RecordId[0]);
-
+				RecordId[] ids = fetchPendingRecordIds(streamKey);
 				if (ids.length > 0) {
-					List<MapRecord<String, String, String>> claimedRaw = streamOperations
-						.claim(streamKey, GROUP, CONSUMER, Duration.ZERO, ids);
-					if (!claimedRaw.isEmpty()) {
-						pendingToAck.addAll(claimedRaw);
-						buffer = claimedRaw.iterator();
-					}
+					List<MapRecord<String, String, String>> claimedRaw = claimRecords(streamKey, ids);
+					processClaimedRecords(claimedRaw);
 				}
 			} catch (Exception e) {
 				log.warn("Pending 메시지 클레임 실패: streamKey={}, error={}", streamKey, e.getMessage());
 			}
 		}
 	}
+
 
 	/**
 	 * 활성 스트림 키에서 새 레코드 묶음을 조회합니다.
@@ -209,37 +198,66 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 * @author 박찬병
 	 * @since 2025-05-27
 	 */
-	private List<MapRecord<String, String, String>> fetchRecords(Set<String> keys) {
-		if (keys.isEmpty()) {
+	private List<MapRecord<String, String, String>> fetchRecords() {
+		if (currentStreamKeys.isEmpty()) {
 			return List.of();
 		}
-		keys.forEach(this::ensureGroup);
+		currentStreamKeys.forEach(this::ensureGroup);
 
-		List<StreamOffset<String>> offsets = new ArrayList<>(keys.size());
-		keys.forEach(k -> offsets.add(StreamOffset.create(k, ReadOffset.lastConsumed())));
+		List<StreamOffset<String>> offsets = new ArrayList<>(currentStreamKeys.size());
+		currentStreamKeys.forEach(k -> offsets.add(StreamOffset.create(k, ReadOffset.lastConsumed())));
 
 		StreamReadOptions opts = StreamReadOptions.empty()
-			.count((long) batchSize * keys.size())
+			.count((long) batchSize * currentStreamKeys.size())
 			.block(Duration.ofMillis(blockMillis / 2));
 
 		return getMapRecords(opts, offsets);
 	}
 
+
 	/**
-	 * 주어진 StreamReadOptions와 offsets로부터 MapRecord를 읽어 반환합니다.
+	 * 주어진 스트림 키에 대해 PENDING 메시지의 RecordId 배열을 조회하여 반환합니다.
 	 *
-	 * @param opts    스트림 읽기 옵션
-	 * @param offsets 읽기를 수행할 StreamOffset 리스트
-	 * @return 읽어온 MapRecord 리스트
+	 * @param streamKey 스트림 키
+	 * @return PENDING 메시지의 RecordId 배열
 	 * @author 박찬병
-	 * @since 2025-05-27
+	 * @since 2025-06-02
 	 */
-	private List<MapRecord<String, String, String>> getMapRecords(StreamReadOptions opts,
-		List<StreamOffset<String>> offsets) {
-		return streamOperations.read(Consumer.from(GROUP, CONSUMER),
-			opts,
-			offsets.toArray(new StreamOffset[0])
-		);
+	private RecordId[] fetchPendingRecordIds(String streamKey) {
+		PendingMessages pending = streamOperations
+			.pending(streamKey, Consumer.from(GROUP, CONSUMER), Range.unbounded(), 100L);
+		List<RecordId> idsList = new ArrayList<>();
+		for (PendingMessage pm : pending) {
+			idsList.add(pm.getId());
+		}
+		return idsList.toArray(new RecordId[0]);
+	}
+
+	/**
+	 * 주어진 스트림 키와 RecordId 배열을 사용하여 메시지를 클레임하고 반환합니다.
+	 *
+	 * @param streamKey 스트림 키
+	 * @param ids RecordId 배열
+	 * @return 클레임된 MapRecord 리스트
+	 * @author 박찬병
+	 * @since 2025-06-02
+	 */
+	private List<MapRecord<String, String, String>> claimRecords(String streamKey, RecordId[] ids) {
+		return streamOperations.claim(streamKey, GROUP, CONSUMER, Duration.ZERO, ids);
+	}
+
+	/**
+	 * 클레임된 레코드를 pendingToAck에 추가하고 buffer를 설정합니다.
+	 *
+	 * @param claimedRaw 클레임된 MapRecord 리스트
+	 * @author 박찬병
+	 * @since 2025-06-02
+	 */
+	private void processClaimedRecords(List<MapRecord<String, String, String>> claimedRaw) {
+		if (!claimedRaw.isEmpty()) {
+			pendingToAck.addAll(claimedRaw);
+			buffer = claimedRaw.iterator();
+		}
 	}
 
 	/**
@@ -262,6 +280,23 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		}
 
 		createGroupSafe(streamKey);
+	}
+
+	/**
+	 * 주어진 StreamReadOptions와 offsets로부터 MapRecord를 읽어 반환합니다.
+	 *
+	 * @param opts    스트림 읽기 옵션
+	 * @param offsets 읽기를 수행할 StreamOffset 리스트
+	 * @return 읽어온 MapRecord 리스트
+	 * @author 박찬병
+	 * @since 2025-05-27
+	 */
+	private List<MapRecord<String, String, String>> getMapRecords(StreamReadOptions opts,
+		List<StreamOffset<String>> offsets) {
+		return streamOperations.read(Consumer.from(GROUP, CONSUMER),
+			opts,
+			offsets.toArray(new StreamOffset[0])
+		);
 	}
 
 	/**

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -11,18 +11,23 @@ import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Range;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.PendingMessage;
+import org.springframework.data.redis.connection.stream.PendingMessages;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.stereotype.Component;
 
 import com.likelion.backendplus4.talkpick.batch.chat.exception.ChatBatchException;
 import com.likelion.backendplus4.talkpick.batch.chat.exception.error.ChatBatchErrorCode;
+import com.likelion.backendplus4.talkpick.batch.common.annotation.logging.EntryExitLog;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,6 +50,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 	private Iterator<MapRecord<String, String, String>> buffer;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final StreamOperations<String, String, String> streamOperations;
 	private final List<MapRecord<String, String, String>> pendingToAck = new ArrayList<>();
 
 	public RedisStreamItemReader(
@@ -52,6 +58,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 		@Value("${chat.flush.interval}") long blockMillis,
 		@Value("${chat.flush.batch-size}") int batchSize) {
 		this.redisTemplate = redisTemplate;
+		this.streamOperations = redisTemplate.opsForStream();
 		this.blockMillis = blockMillis;
 		this.batchSize = batchSize;
 	}
@@ -71,6 +78,8 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public void open(ExecutionContext executionContext) throws ItemStreamException {
 		this.buffer = null;
+		claimOldPendingMessages();
+
 	}
 
 	/**
@@ -131,7 +140,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 				RecordId[] ids = recList.stream()
 					.map(MapRecord::getId)
 					.toArray(RecordId[]::new);
-				redisTemplate.opsForStream().acknowledge(streamKey, GROUP, ids);
+				streamOperations.acknowledge(streamKey, GROUP, ids);
 			});
 	}
 
@@ -177,7 +186,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 */
 	private List<MapRecord<String, String, String>> getMapRecords(StreamReadOptions opts,
 		List<StreamOffset<String>> offsets) {
-		return redisTemplate.opsForStream().read(Consumer.from(GROUP, CONSUMER),
+		return streamOperations.read(Consumer.from(GROUP, CONSUMER),
 			opts,
 			offsets.toArray(new StreamOffset[0])
 		);
@@ -225,14 +234,40 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 */
 	private void createGroupSafe(String streamKey) {
 		try {
-			redisTemplate.opsForStream()
-				.createGroup(streamKey, ReadOffset.from("0"), GROUP);
+			streamOperations.createGroup(streamKey, ReadOffset.from("0"), GROUP);
 		} catch (Exception ex) {
 			if (String.valueOf(ex.getMessage()).contains("BUSYGROUP")) {
 				return;
 			}
 			log.error("스트림 {}에 대한 컨슈머 그룹 생성에 실패했습니다.", streamKey, ex);
 			throw new ChatBatchException(ChatBatchErrorCode.REDIS_GROUP_CREATE_FAILED, ex);
+		}
+	}
+
+	@EntryExitLog
+	private void claimOldPendingMessages() {
+		Set<String> keys = streamKeys();
+		if (keys.isEmpty()) return;
+
+		for (String streamKey : keys) {
+			try {
+				PendingMessages pending = streamOperations
+					.pending(streamKey, Consumer.from(GROUP, CONSUMER), Range.unbounded(), 100L);
+
+				List<RecordId> idsList = new ArrayList<>();
+				for (PendingMessage pm : pending) {
+					idsList.add(pm.getId());
+				}
+				RecordId[] ids = idsList.toArray(new RecordId[0]);
+
+				if (ids.length > 0) {
+					List<MapRecord<String, String, String>> claimedRaw = streamOperations
+						.claim(streamKey, GROUP, CONSUMER, Duration.ofMillis(0), ids);
+					pendingToAck.addAll(claimedRaw);
+				}
+			} catch (Exception e) {
+				log.warn("Pending 메시지 클레임 실패: streamKey={}, error={}", streamKey, e.getMessage());
+			}
 		}
 	}
 

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -111,7 +111,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 */
 	@Override
 	public MapRecord<String, String, String> read() {
-		if (buffer == null || !buffer.hasNext()) {
+		if (null == buffer|| !buffer.hasNext()) {
 			List<MapRecord<String, String, String>> recs = fetchRecords();
 			log.info("읽어온 recs = {}", recs.size());
 			if (recs.isEmpty()) {
@@ -167,7 +167,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 */
 	@EntryExitLog
 	private void claimOldPendingMessages() {
-		if (currentStreamKeys == null || currentStreamKeys.isEmpty()) {
+		if (null == currentStreamKeys || currentStreamKeys.isEmpty()) {
 			return;
 		}
 		for (String streamKey : currentStreamKeys) {

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -97,6 +97,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	@Override
 	public void close() throws ItemStreamException {
 		pendingToAck.clear();
+		pendingReadIndex = 0;
 	}
 
 	/**
@@ -113,14 +114,6 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 */
 	@Override
 	public MapRecord<String, String, String> read() {
-		if (pendingReadIndex < pendingToAck.size()) {
-			MapRecord<String, String, String> record = pendingToAck.get(pendingReadIndex);
-			log.info("read(): pendingToAck에서 인덱스 {}로 조회, 전체 개수 = {}", pendingReadIndex, pendingToAck.size());
-			pendingReadIndex++;
-			return record;
-		}
-
-		pendingReadIndex = 0;
 		if (buffer == null || !buffer.hasNext()) {
 			List<MapRecord<String, String, String>> recs = fetchRecords(currentStreamKeys);
 			log.info("읽어온 recs = {}", recs.size());
@@ -157,7 +150,6 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 			});
 		// After acknowledging all pendingToAck entries, clear the list and reset index
 		pendingToAck.clear();
-		pendingReadIndex = 0;
 	}
 
 	/**
@@ -194,6 +186,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 						.claim(streamKey, GROUP, CONSUMER, Duration.ZERO, ids);
 					if (!claimedRaw.isEmpty()) {
 						pendingToAck.addAll(claimedRaw);
+						buffer = claimedRaw.iterator();
 					}
 				}
 			} catch (Exception e) {

--- a/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
+++ b/src/main/java/com/likelion/backendplus4/talkpick/batch/chat/infrastructure/adapter/out/batch/reader/RedisStreamItemReader.java
@@ -12,6 +12,7 @@ import org.springframework.batch.item.ItemStreamException;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.RedisStreamCommands;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessage;
@@ -20,6 +21,7 @@ import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StreamOperations;
@@ -50,6 +52,7 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	private final RedisTemplate<String, String> redisTemplate;
 	private final StreamOperations<String, String, String> streamOperations;
 	private final List<MapRecord<String, String, String>> pendingToAck = new ArrayList<>();
+	private int pendingReadIndex = 0;
 
 	private Iterator<MapRecord<String, String, String>> buffer;;
 	private Set<String> currentStreamKeys;
@@ -110,7 +113,15 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 	 */
 	@Override
 	public MapRecord<String, String, String> read() {
-		if (null == buffer || !buffer.hasNext()) {
+		if (pendingReadIndex < pendingToAck.size()) {
+			MapRecord<String, String, String> record = pendingToAck.get(pendingReadIndex);
+			log.info("read(): pendingToAck에서 인덱스 {}로 조회, 전체 개수 = {}", pendingReadIndex, pendingToAck.size());
+			pendingReadIndex++;
+			return record;
+		}
+
+		pendingReadIndex = 0;
+		if (buffer == null || !buffer.hasNext()) {
 			List<MapRecord<String, String, String>> recs = fetchRecords(currentStreamKeys);
 			log.info("읽어온 recs = {}", recs.size());
 			if (recs.isEmpty()) {
@@ -144,6 +155,9 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 					.toArray(RecordId[]::new);
 				streamOperations.acknowledge(streamKey, GROUP, ids);
 			});
+		// After acknowledging all pendingToAck entries, clear the list and reset index
+		pendingToAck.clear();
+		pendingReadIndex = 0;
 	}
 
 	/**
@@ -160,7 +174,9 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 	@EntryExitLog
 	private void claimOldPendingMessages(Set<String> keys) {
-		if (keys.isEmpty()) return;
+		if (keys.isEmpty()) {
+			return;
+		}
 
 		for (String streamKey : keys) {
 			try {
@@ -175,8 +191,10 @@ public class RedisStreamItemReader implements ItemStreamReader<MapRecord<String,
 
 				if (ids.length > 0) {
 					List<MapRecord<String, String, String>> claimedRaw = streamOperations
-						.claim(streamKey, GROUP, CONSUMER, Duration.ofMillis(0), ids);
-					pendingToAck.addAll(claimedRaw);
+						.claim(streamKey, GROUP, CONSUMER, Duration.ZERO, ids);
+					if (!claimedRaw.isEmpty()) {
+						pendingToAck.addAll(claimedRaw);
+					}
 				}
 			} catch (Exception e) {
 				log.warn("Pending 메시지 클레임 실패: streamKey={}, error={}", streamKey, e.getMessage());


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결

## ✨ 변경 사항
- **`claimOldPendingMessages()` 진입점 추가**  
  - `open(ExecutionContext)` 단계에서 호출되어, 활성 스트림 키들(`currentStreamKeys`)에 남아 있는 PENDING 메시지 전체를 처리하도록 구현했습니다.  
  - 내부적으로 `fetchPendingRecordIds()`, `claimRecords()`, `processClaimedRecords()` 순으로 호출되어 다음 동작을 수행합니다:
  1. **`fetchPendingRecordIds(String streamKey)`**  
     - 해당 스트림 키의 PENDING 메시지 ID 목록을 최대 100건까지 조회하여 `RecordId[]` 형태로 반환합니다.  
  2. **`claimRecords(String streamKey, RecordId[] ids)`**  
     - 조회된 ID 배열을 즉시(`Duration.ZERO`) 클레임(claim)하여, 본 컨슈머(`batch-reader`)가 메시지를 가져오도록 합니다.  
     - 반환된 `List<MapRecord<String,String,String>>`에 실제 메시지 본문이 담겨 있습니다.  
  3. **`processClaimedRecords(List<MapRecord<String, String, String>> claimedRaw)`**  
     - 클레임된 메시지 리스트를 전역 `pendingToAck`에 추가하고, `buffer` iterator를 `claimedRaw.iterator()`로 설정하여 이후 `read()`에서 순차적으로 반환할 수 있도록 합니다.
- **`open(ExecutionContext)` 수정**  
  - 기존 `buffer = null` 초기화 이후에 곧바로 `claimOldPendingMessages()`를 호출하여, 애플리케이션(혹은 Spring Batch Step) 시작 시점에 남아 있는 Pending 메시지를 우선 처리하도록 변경했습니다.
- **`fetchPendingRecordIds()`, `claimRecords()`, `processClaimedRecords()` 메서드 신설**  
  - `fetchPendingRecordIds()`: 스트림 키별 PENDING 메시지를 조회  
  - `claimRecords()`: PENDING된 ID를 기반으로 메시지를 클레임  
  - `processClaimedRecords()`: 클레임된 메시지를 내부 큐에 적재  

## 🔍 리뷰어에게
- **Pending 메시지 조회/클레임 흐름 점검**  
  - `fetchPendingRecordIds()`가 스트림 키별로 누락 없이 모든 Pending ID를 조회하는지, 특히 PENDING 메시지가 100건을 초과할 때 페이징 처리나 추가 조회가 필요한지 확인 부탁드립니다.  
  - `claimRecords()` 호출 시 `Duration.ZERO`로 즉시 클레임하도록 했는데, 이로 인해 실제로 예상대로 모든 PENDING 메시지를 가져오는지, 혹은 Redis 연결 예외 발생 시 재시도 로직이 필요한지 검토해 주세요.
- **`processClaimedRecords()`와 기존 Fetch 흐름 충돌 여부**  
  - `processClaimedRecords()`에서 `buffer`를 `claimedRaw.iterator()`로 초기화함으로써 이후 `read()` 호출 시 Pending 메시지가 우선 반환됩니다. 이 과정이 기존 `fetchRecords()` 호출 흐름과 충돌 없이 정상 작동하는지, 특히 첫 `read()` 호출 전에 `pendingToAck`가 올바르게 초기화되는지 확인 바랍니다.
- **유닛 테스트 및 통합 테스트**  
  - 애플리케이션(또는 배치) 재기동 시, 이전 실행에서 ACK되지 못하고 남아 있는 PENDING 메시지를 `claimOldPendingMessages()`가 정상적으로 클레임하여 `read()`로 반환하는 시나리오를 테스트해 주세요.  
  - 새로운 스트림 키가 생성되었을 때(`chat:stream:newRoom` 등), `ensureGroup()`가 정상적으로 컨슈머 그룹을 생성하고 이후 Pending 처리 흐름에 문제가 없는지 검증 부탁드립니다.
- **성능 및 리소스 고려**  
  - 최대 100건까지 조회하는 현재 설정에서, 실제 운영 환경에서 PENDING 메시지가 수백 건 이상 쌓일 경우 처리 성능이 저하될 가능성이 있는지 점검해 주세요. 필요한 경우 페이징 처리나 배치 크기 제한 방안을 논의해 주시면 좋습니다.  
  - `pendingToAck`에 한 번에 많은 메시지가 적재될 때 메모리 사용량이 급증하지 않는지, `read()`와 `ackPending()` 사이에서 적절한 청크 크기를 유지하는지 확인 부탁드립니다.


## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.


## 🔗 관련 이슈
- closed #92 